### PR TITLE
[BUG] fix import error in `taxonomies` module

### DIFF
--- a/src/aiod/taxonomies/__init__.py
+++ b/src/aiod/taxonomies/__init__.py
@@ -85,7 +85,7 @@ class Term:
     taxonomy: str
     term: str
     definition: str
-    subterms: list[Term]
+    subterms: list["Term"]
 
     def __eq__(self, other):
         return self.taxonomy == other.taxonomy and self.term == other.term
@@ -94,7 +94,7 @@ class Term:
 class _TermDict(TypedDict):
     term: str
     definition: str
-    subterms: list[_TermDict]
+    subterms: list["_TermDict"]
 
 
 def _parse_term(term: _TermDict, taxonomy: str) -> Term:


### PR DESCRIPTION
Fixes https://github.com/aiondemand/aiondemand/issues/49.

This was caused by use of a class name that was never imported.