### PR TITLE
[BUG] changed the timeout config

### DIFF
--- a/src/aiod/configuration/_config.py
+++ b/src/aiod/configuration/_config.py
@@ -44,7 +44,7 @@ class Config:
     auth_server: str = "https://auth.aiod.eu/aiod-auth/"
     realm: str = "aiod"
     client_id: str = "aiod-sdk"
-    request_timeout_seconds: int = 100
+    request_timeout_seconds: int = 10
 
     _observers: dict[str, set[AttributeObserver]] = field(
         default_factory=lambda: defaultdict(set),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,7 @@ LATEST_VERSION_MARKER = ""
 def test_get_dataset_list_from_default_version_server(version: str):
     if version == LATEST_VERSION_MARKER:
         aiod.config.version = LATEST_VERSION_MARKER
+    aiod.config.request_timeout_seconds = 100
     datasets = aiod.datasets.get_list()
     assert len(datasets) == 10
     dataset = aiod.datasets.get_asset(datasets["identifier"].iloc[0])


### PR DESCRIPTION
Fixed the timeout test fail in the main branch 

Change
- Increased request_timeout_seconds from 10 to 100 to prevent timeout errors during integration tests.

Fixes #46