### PR TITLE
[MNT] Update pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-per-file-ignores = __init__.py:F401
-max-line-length = 130

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 **__pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.13.0
+    rev: v0.15.1
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -10,7 +10,7 @@ repos:
       - id: ruff-format
         files: src/.*
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.19.1
     hooks:
       - id: mypy
         name: mypy src
@@ -19,19 +19,3 @@ repos:
           - types-requests
           - types-python-dateutil
           - types-pytz
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        name: flake8 src
-        files: src/.*
-        additional_dependencies:
-          - flake8-print==5.0.0
-  - repo: local
-    hooks:
-      - id: pytest-check
-        name: pytest-check
-        entry: pytest tests
-        language: system
-        pass_filenames: false
-        always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,16 @@ addopts = "-m 'not server'"
 
 [tool.ruff]
 fix = true
+line-length = 130
 
 [tool.ruff.lint]
 select = [
     "D",  # enables pydocstyle checks
+    "T20",  # flake8-print (replaces flake8-print plugin)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]  # ignore unused imports in __init__.py
 ignore = [
     "D100",
     "D101",


### PR DESCRIPTION
Changes:
- Delete .flake8 and migrate settings to pyproject.toml ruff config (per-file-ignores for F401 in __init__.py, max-line-length=130, T20 for print checks)
- Remove pytest-check hook from pre-commit (slows down pre-commit unnecessarily)
- Remove flake8 hook (replaced by ruff which covers all flake8 checks)
- Update ruff: v0.13.0 -> v0.15.1
- Update mypy: v0.991 -> v1.19.1
- Add .ruff_cache/ to .gitignore

<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
<!-- Briefly describe the change of this PR -->


## How to Test
<!-- Describe a way to test the change of this PR -->

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
<!-- Provide a list of relevant issues and/or pull requests, if any. -->
<!-- If the pull request closes and issue, specify "Closes #X" (where X is the issue number). -->


