### PR TITLE
[MNT] set `fail-fast: false` in CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ concurrency:
 jobs:
   test-code:
     runs-on: ${{ matrix.os }}
-    fail-fast: false
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
sets `fail-fast: false` in CI tests.

For now, tests run quickly, and it is better to have multiple runs that flag sporadic failures rather than a single failing run that cancels all the others. This is in particular useful for detecting race conditions in tests.