### PR TITLE
[DOC] Fix HTTP to HTTPS link in Code of Conduct

### DIFF
--- a/docs/conduct.md
+++ b/docs/conduct.md
@@ -40,4 +40,4 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant homepage](http://contributor-covenant.org/version/1/4), version 1.4.
+This Code of Conduct is adapted from the [Contributor Covenant homepage](https://contributor-covenant.org/version/1/4), version 1.4.


### PR DESCRIPTION
  ## Change                                                                                                                                                                        
                                                                                                                                                                                   
  Fixed the Contributor Covenant link in `docs/conduct.md` from `http://` to `https://`. The site supports HTTPS and using the secure protocol is a best practice. 
  ## How to Test         
  - Verify the updated link resolves correctly: [https://contributor-covenant.org/version/1/4](https://contributor-covenant.org/version/1/4)
  - Run `mkdocs serve` locally and confirm the Code of Conduct page renders the link properly.

  ## Checklist
  - [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
    - No tests needed .this is a single URL protocol change in a markdown file.
  - [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
    - This PR *is* the documentation fix.
  - [x] A self-review has been conducted checking:
    - No unintended changes have been committed.
    - The changes in isolation seem reasonable.
    - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
  - [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

  ## Related Issues

  None .found during a documentation audit.