### PR TITLE
[DOC] replace stale develop branch references with main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "develop"  # Necessary to download the latest of develop as this will have been updated on the step before
+          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
           fetch-tags: 1
           fetch-depth: 0
       - uses: actions/setup-python@v5
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "develop"  # Necessary to download the latest of develop as this will have been updated on the step before
+          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
           fetch-tags: 1
           fetch-depth: 0
       - name: Download the build artifiact
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "develop"  # Necessary to download the latest of develop as this will have been updated on the step before
+          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
       - uses: actions/download-artifact@v4
         with:
             name: build-output

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,11 +81,11 @@ All tests should pass.
 
 ### Making Changes
 
-While working on a feature, you can work from the "develop"-branch, provided you are working on a fork.
+While working on a feature, you can work from the "main"-branch, provided you are working on a fork.
 However, even if you are working on a fork we strongly recommend you to make changes on a new branch.
 When working on the main repository, this is required. When working on a fork, this makes it easier to 
 keep your fork in sync with the upstream repository (this one).
-Your new branch should branch off "develop":
+Your new branch should branch off "main":
 
 ```console
 git checkout -b name-of-your-bugfix-or-feature


### PR DESCRIPTION
## Change
Replace all stale `develop` branch references with `main` across CI/CD workflows and documentation. The `develop` branch no longer exists, causing broken release pipelines and confusing contributor instructions.

## Files Changed
release.yaml — Changed ref: "develop" to ref: "main" in the build, release, and publish jobs (3 places). These were silently breaking releases.
docs.yml — Removed the dead develop trigger from the push branches list.
contributing.md — Updated branching instructions to say main instead of develop.

## How to Test
Trigger the release workflow manually — it should now correctly checkout `main` after a version bump instead of failing on a non-existent branch.

## Checklist
- [x] A self-review has been conducted; no unintended changes have been committed.
- [x] Documentation has been updated to reflect the changes.
- [x] The changes in isolation seem reasonable.

## Related Issues
Closes #109 

> cc @fkiraly — happy to revert if there are plans to reintroduce a `develop` branch. Otherwise this unblocks the release pipeline immediately.