### PR TITLE
[ENH] automation to generate sklearn estimator index class source (part 1)

### DIFF
--- a/src/aiod/utils/_indexing/__init__.py
+++ b/src/aiod/utils/_indexing/__init__.py
@@ -1,1 +1,5 @@
 """Utilities module for indexing third party libraries."""
+
+from aiod.utils._indexing._preindex_sklearn import generate_sklearn_index_source
+
+__all__ = ["generate_sklearn_index_source"]

--- a/src/aiod/utils/_indexing/_preindex_sklearn.py
+++ b/src/aiod/utils/_indexing/_preindex_sklearn.py
@@ -6,6 +6,8 @@ __author__ = ["fkiraly"]
 # all_estimators is also based on the sklearn utility of the same name
 
 import inspect
+import re
+from pprint import pformat
 
 from skbase.lookup import all_objects
 
@@ -239,3 +241,108 @@ def _generate_sklearn_types_of_obj() -> dict:
             type_of_objs[est_name] = found_types[0]
 
     return type_of_objs
+
+
+def _sanitize_class_suffix(name: str) -> str:
+    """Sanitize string for usage in generated class names."""
+    pieces = re.split(r"[^0-9a-zA-Z]+", name)
+    return "".join(piece[:1].upper() + piece[1:] for piece in pieces if piece)
+
+
+def _normalize_object_types(obj_types: str | list[str] | None) -> list[str]:
+    """Return object types in normalized list form."""
+    if obj_types is None:
+        return []
+    if isinstance(obj_types, str):
+        return [obj_types]
+    return list(obj_types)
+
+
+def generate_sklearn_index_source(
+    pypi_package_name="scikit-learn",
+    import_root="sklearn",
+    class_name=None,
+    mode="multiple",
+):
+    """Generate source code for sklearn index package class(es).
+
+    Parameters
+    ----------
+    pypi_package_name : str, default="scikit-learn"
+        Name of the package in PyPI metadata.
+    import_root : str, default="sklearn"
+        Import root used to discover sklearn-style estimators.
+    class_name : str or None, optional
+        Name of class to generate in ``mode='multiple'``.
+        If None, this defaults to ``AiodPkg__{ImportRoot}``.
+    mode : {"multiple", "single"}, default="multiple"
+        If ``"multiple"``, generates one class with ``_obj_dict``, ``_type_of_objs``
+        and ``_objs_by_type``.
+        If ``"single"``, generates one single-object class per estimator.
+
+    Returns
+    -------
+    str
+        Python source code for generated class definition(s).
+    """
+    if mode not in {"multiple", "single"}:
+        raise ValueError("mode must be one of {'multiple', 'single'}")
+
+    obj_dict = _all_sklearn_estimators_locdict(package_name=import_root)
+    type_of_objs = _generate_sklearn_types_of_obj()
+    objs_by_type = _generate_sklearn_objs_by_type(type_of_objs)
+
+    lines = [
+        '"""Generated sklearn index class(es)."""',
+        "",
+        "from aiod.models.apis import _ModelPkgSklearnEstimator",
+        "",
+        "",
+    ]
+
+    if mode == "multiple":
+        if class_name is None:
+            class_name = f"AiodPkg__{_sanitize_class_suffix(import_root)}"
+
+        object_types = sorted(objs_by_type.keys())
+
+        lines.extend(
+            [
+                f"class {class_name}(_ModelPkgSklearnEstimator):",
+                "    _tags = {",
+                '        "pkg_id": "__multiple",',
+                f'        "python_dependencies": "{pypi_package_name}",',
+                f'        "pkg_pypi_name": "{pypi_package_name}",',
+                f"        \"object_types\": {pformat(object_types)},",
+                "    }",
+                "",
+                f"    _obj_dict = {pformat(obj_dict, sort_dicts=True)}",
+                "",
+                f"    _type_of_objs = {pformat(type_of_objs, sort_dicts=True)}",
+                "",
+                f"    _objs_by_type = {pformat(objs_by_type, sort_dicts=True)}",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    for estimator_name in sorted(obj_dict):
+        estimator_class_name = f"AiodPkg__{_sanitize_class_suffix(estimator_name)}"
+        estimator_obj_types = _normalize_object_types(type_of_objs.get(estimator_name))
+        lines.extend(
+            [
+                f"class {estimator_class_name}(_ModelPkgSklearnEstimator):",
+                "    _tags = {",
+                f'        "pkg_id": "{estimator_name}",',
+                f'        "python_dependencies": "{pypi_package_name}",',
+                f'        "pkg_pypi_name": "{pypi_package_name}",',
+                f"        \"object_types\": {pformat(estimator_obj_types)},",
+                "    }",
+                "",
+                f'    _obj = "{obj_dict[estimator_name]}"',
+                "",
+                "",
+            ]
+        )
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_preindex.py
+++ b/tests/test_preindex.py
@@ -1,1 +1,50 @@
-"""Test preindex"""
+"""Tests for preindex generation utilities."""
+
+import pytest
+
+from aiod.utils._indexing import generate_sklearn_index_source
+from aiod.utils._indexing._preindex_sklearn import (
+	_all_sklearn_estimators_locdict,
+	_generate_sklearn_objs_by_type,
+	_generate_sklearn_types_of_obj,
+)
+
+
+pytest.importorskip("sklearn")
+
+
+def test_generate_sklearn_index_source_multiple_contains_core_fragments():
+	source = generate_sklearn_index_source()
+
+	assert "class AiodPkg__Sklearn(_ModelPkgSklearnEstimator):" in source
+	assert '"pkg_id": "__multiple"' in source
+	assert '"python_dependencies": "scikit-learn"' in source
+	assert "_obj_dict" in source
+	assert "_type_of_objs" in source
+	assert "_objs_by_type" in source
+
+
+def test_generate_sklearn_index_source_multiple_exec_matches_utils():
+	source = generate_sklearn_index_source()
+	namespace = {}
+
+	exec(source, namespace)
+
+	generated_cls = namespace["AiodPkg__Sklearn"]
+
+	expected_obj_dict = _all_sklearn_estimators_locdict(package_name="sklearn")
+	expected_type_of_objs = _generate_sklearn_types_of_obj()
+	expected_objs_by_type = _generate_sklearn_objs_by_type(expected_type_of_objs)
+
+	assert generated_cls._obj_dict == expected_obj_dict
+	assert generated_cls._type_of_objs == expected_type_of_objs
+	assert generated_cls._objs_by_type == expected_objs_by_type
+
+
+def test_generate_sklearn_index_source_single_mode_contains_single_class_entries():
+	source = generate_sklearn_index_source(mode="single")
+
+	assert "class AiodPkg__RandomForestClassifier(_ModelPkgSklearnEstimator):" in source
+	assert '"pkg_id": "RandomForestClassifier"' in source
+	assert '"pkg_pypi_name": "scikit-learn"' in source
+	assert '_obj = "sklearn.ensemble.RandomForestClassifier"' in source


### PR DESCRIPTION
## Change

This PR adds automation to generate estimator index class source code for scikit-learn (issue #118, part 1).

The new utility generates valid Python source for AIoD model package classes by composing the existing preindex discovery utilities. It supports both:

- multiple-estimator package format (single class with _obj_dict, _type_of_objs, _objs_by_type)
- single-estimator package format (one class per estimator with _obj and per-class tags)

---

## Motivation

Maintaining large static index classes by hand is error-prone and hard to keep in sync with upstream package changes.
This change introduces a reusable generator so index classes can be created programmatically from discovered estimators and type mappings.

---

## What was added

### 1) Source generator utility

Added generate_sklearn_index_source(...) in the sklearn preindex utilities.

Current interface:
- pypi_package_name="scikit-learn"
- import_root="sklearn"
- class_name=None
- mode="multiple" (or "single")

Behavior:
- discovers estimator locations via existing locator utility
- derives estimator type mapping via existing type generator
- derives reverse index (objects by type) via existing helper
- renders complete Python source string for generated class(es)

### 2) Helper utilities for robust generation

Added internal helpers to:
- sanitize class name suffixes for generated class names
- normalize object-type values to list form where needed

### 3) Public export

Exposed generate_sklearn_index_source from aiod.utils._indexing so callers can import it from the indexing package root.

### 4) Tests

Added focused tests for:
- generated source structure in multiple mode
- executable correctness (generated class dictionaries match utility outputs)
- expected class/object snippets in single mode

---

## Design notes

- The generator intentionally composes existing utilities rather than re-implementing discovery logic.
- Output is generated as a Python source string so callers can:
  - write to a file directly, or
  - use generated content in other automation flows.
- mode="multiple" defaults class naming to AiodPkg__{ImportRoot} unless class_name is explicitly provided.

---

## Validation

Executed:
- pytest -q tests/test_preindex.py

Result:
- 3 passed

---

## Backward compatibility

- No breaking API changes to existing runtime model retrieval.
- New functionality is additive (new utility + export + tests).

---

## Follow-up scope (not included in this PR)

- generalized non-sklearn package support
- richer class naming/config customization
- integration into an end-to-end generate-and-write command flow

---

## Related Issues

Fixes #118
