### PR TITLE
docs : script triggers bash history expansion

### DIFF
--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -54,7 +54,7 @@ pip install -e ".[dev]"
 
 **Quick check**:
 ```bash
-python -c "import aiod; print('aiondemand installed successfully!')"
+python -c 'import aiod; print("aiondemand installed successfully!")'
 ```
 
 ---


### PR DESCRIPTION
## Change
Small fix I found while trying to setup the repo . Swapped out the quotes to prevent accidental history expansion when running the python command


## How to Test
` python -c 'import aiod; print("aiondemand installed successfully!")' ` prints out appropriate message

Checklist
- [ ] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x]  Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x]  A self review has been conducted checking:
         ◦ No unintended changes have been committed.
         ◦ The changes in isolation seem reasonable.
         ◦ Anything that may be odd or unintuitive is provided with a GitHub comment.
 - [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
 - [x] The PR title matches the changelog entry's one line description.
