### PR TITLE
[ENH] Add backend-independent LLM utility for artefact–publication linkage (Closes #104)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ doc = [
 tests_integrations = [
     "scikit-learn",
 ]
+linkage = [
+    "pypdf",
+    "litellm",
+    "beautifulsoup4",
+]
 
 [build-system]
 requires = ["hatchling >= 1.26"]

--- a/src/aiod/linkage_cli.py
+++ b/src/aiod/linkage_cli.py
@@ -1,0 +1,152 @@
+"""CLI entry point for the publication-code linkage extractor.
+
+Usage::
+
+    python -m aiod.linkage_cli <paper-identifier> --model <litellm-model> [options]
+
+Examples::
+
+    # From a DOI
+    python -m aiod.linkage_cli "10.48550/arXiv.2307.09288" --model openai/gpt-4o
+
+    # From a Zenodo link
+    python -m aiod.linkage_cli "https://zenodo.org/records/12345" --model anthropic/claude-3.5-sonnet
+
+    # From a local PDF
+    python -m aiod.linkage_cli paper.pdf --model ollama/llama3
+
+    # JSON output
+    python -m aiod.linkage_cli paper.pdf --model openai/gpt-4o --output json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+
+from aiod.linkage_extractor import (
+    CodeLinkage,
+    LiteLLMBackend,
+    extract_linkages_from_paper,
+)
+
+
+def _format_table(linkages: list[CodeLinkage]) -> str:
+    """Format linkages as a human-readable ASCII table."""
+    if not linkages:
+        return "No linkages found."
+
+    # Column definitions: (header, accessor, min_width)
+    columns = [
+        ("Artefact ID", lambda l: l.artefact_id, 20),
+        ("Type", lambda l: l.artefact_type.value, 18),
+        ("Relation", lambda l: l.relation.value, 28),
+        ("Confidence", lambda l: f"{l.confidence:.2f}" if l.confidence is not None else "-", 10),
+        ("Comment", lambda l: l.comment or "", 30),
+    ]
+
+    # Determine column widths
+    widths = []
+    for header, accessor, min_w in columns:
+        col_max = max(len(accessor(l)) for l in linkages)
+        widths.append(max(len(header), col_max, min_w))
+
+    # Build header
+    header_line = " | ".join(
+        h.ljust(w) for (h, _, _), w in zip(columns, widths)
+    )
+    separator = "-+-".join("-" * w for w in widths)
+
+    # Build rows
+    rows = []
+    for linkage in linkages:
+        row = " | ".join(
+            accessor(linkage).ljust(w)
+            for (_, accessor, _), w in zip(columns, widths)
+        )
+        rows.append(row)
+
+    return "\n".join([header_line, separator, *rows])
+
+
+def _format_json(linkages: list[CodeLinkage]) -> str:
+    """Format linkages as a JSON string."""
+    data = []
+    for l in linkages:
+        d = asdict(l)
+        d["artefact_type"] = l.artefact_type.value
+        d["relation"] = l.relation.value
+        data.append(d)
+    return json.dumps(data, indent=2)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the linkage CLI."""
+    parser = argparse.ArgumentParser(
+        prog="aiod.linkage_cli",
+        description=(
+            "Extract code artefact linkages (GitHub repos, PyPI packages) "
+            "from a scientific paper using an LLM."
+        ),
+    )
+    parser.add_argument(
+        "paper",
+        help=(
+            "Paper identifier: file path, DOI (e.g. 10.xxx/yyy), "
+            "Zenodo URL, or arbitrary URL."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help=(
+            "LLM model identifier for litellm "
+            "(e.g. 'openai/gpt-4o', 'anthropic/claude-3.5-sonnet')."
+        ),
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="API key for the LLM provider (or set via env vars).",
+    )
+    parser.add_argument(
+        "--api-base",
+        default=None,
+        help="Base URL for self-hosted LLM endpoints.",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["json", "table"],
+        default="table",
+        help="Output format (default: table).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the linkage extraction CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    backend = LiteLLMBackend(
+        model=args.model,
+        api_key=args.api_key,
+        api_base=args.api_base,
+    )
+
+    try:
+        linkages = extract_linkages_from_paper(args.paper, backend=backend)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.output == "json":
+        print(_format_json(linkages))
+    else:
+        print(_format_table(linkages))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aiod/linkage_extractor.py
+++ b/src/aiod/linkage_extractor.py
@@ -1,0 +1,565 @@
+"""Utilities for extracting and classifying code artefact linkages from papers.
+
+This module is intentionally **backend-agnostic**: it defines a small interface
+(``LLMBackend``) that you can implement for any concrete LLM provider
+(OpenAI, Anthropic, local models, etc.).  The high-level orchestration
+(``extract_linkages_from_paper``) only depends on that interface.
+
+The primary workflow is:
+
+1. Resolve a paper identifier (Zenodo link, DOI, local PDF path, or raw text)
+   into plain text.
+2. Call an ``LLMBackend`` implementation to turn that text into structured
+   ``CodeLinkage`` objects containing:
+   - which artefact (e.g. GitHub repo or PyPI package),
+   - what kind of artefact it is,
+   - how it relates to the paper (official implementation, used in experiments,
+     etc.),
+   - and optional comments.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class RelationType(str, Enum):
+    """Relation between a paper and a code artefact."""
+
+    OFFICIAL_IMPLEMENTATION = "official_implementation"
+    """Official implementation of an algorithm proposed in the paper."""
+
+    UNOFFICIAL_IMPLEMENTATION = "unofficial_implementation"
+    """Community / third-party implementation of an algorithm in the paper."""
+
+    CODE_USED_IN_EXPERIMENTS = "code_used_in_experiments"
+    """Code that is used (e.g. as a baseline or framework) in the experiments."""
+
+    CODE_CITED_NOT_USED = "code_cited_not_used"
+    """Code that is only cited, not actually used in experiments."""
+
+    OTHER = "other"
+    """Any other relation not covered by the above."""
+
+
+class ArtefactType(str, Enum):
+    """Types of artefacts we link to."""
+
+    GITHUB_REPOSITORY = "github_repository"
+    PYPI_PACKAGE = "pypi_package"
+    OTHER = "other"
+
+
+@dataclass
+class CodeLinkage:
+    """Structured description of a paper-code linkage."""
+
+    artefact_id: str
+    """Identifier of the artefact (e.g. 'owner/repo' or 'package-name')."""
+
+    artefact_type: ArtefactType
+    """What kind of artefact this is (GitHub repo, PyPI package, etc.)."""
+
+    relation: RelationType
+    """How the artefact relates to the paper."""
+
+    comment: str | None = None
+    """Optional free-form explanation by the LLM."""
+
+    confidence: float | None = None
+    """Optional confidence score in [0, 1]."""
+
+
+# Simple list kept for compatibility / easier prompting
+RELATION_CATEGORIES: List[str] = [r.value for r in RelationType]
+
+
+# ---------------------------------------------------------------------------
+# Shared prompt/parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_extraction_prompt(paper_text: str) -> str:
+    """Build a backend-agnostic prompt describing the desired JSON schema."""
+    relation_desc = textwrap.dedent("""\
+        Relation categories you MUST use (field "relation"):
+
+        - "official_implementation": official implementation of an algorithm proposed in the paper
+        - "unofficial_implementation": third-party implementation of an algorithm from the paper
+        - "code_used_in_experiments": code used in experiments (e.g. baselines, frameworks, libraries)
+        - "code_cited_not_used": code that is only cited or discussed, not actually used
+        - "other": any other relation
+    """).strip()
+
+    schema_desc = textwrap.dedent("""\
+        Return a JSON array. Each element MUST have this shape:
+
+        {
+          "artefact_id": "string, e.g. 'owner/repo' or 'package-name'",
+          "artefact_type": "github_repository | pypi_package | other",
+          "relation": "one of official_implementation | unofficial_implementation | code_used_in_experiments | code_cited_not_used | other",
+          "comment": "optional short natural-language explanation",
+          "confidence": 0.0-1.0 optional numeric confidence
+        }
+
+        Only include artefacts that you believe are truly related to the paper.
+    """).strip()
+
+    instructions = textwrap.dedent(f"""\
+        You are an expert in scientific software discovery.
+
+        Given the full text of a scientific paper, identify GitHub repositories
+        and Python packages (PyPI identifiers) that are related to the paper.
+
+        - Prefer artefacts that are official or clearly linked in the text
+          (e.g. in "Code availability" sections, footnotes, or URLs).
+        - Also include well-known libraries that are central to the experiments.
+        - Distinguish between official vs unofficial implementations and
+          between code that is actually used vs only cited.
+
+        {relation_desc}
+
+        {schema_desc}
+
+        Reply with JSON ONLY. Do not include any explanation outside the JSON.
+    """).strip()
+
+    return instructions + "\n\nPaper text:\n" + paper_text
+
+
+def _parse_linkage_response(response: str) -> List[CodeLinkage]:
+    """Parse an LLM JSON response into ``CodeLinkage`` objects.
+
+    Handles common quirks like markdown fences around the JSON.
+    """
+    cleaned = response.strip()
+
+    # Strip markdown code fences if present (```json ... ```)
+    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)```", cleaned, re.DOTALL)
+    if fence_match:
+        cleaned = fence_match.group(1).strip()
+
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise ValueError("LLM response is not valid JSON") from exc
+
+    if not isinstance(data, list):
+        raise ValueError("LLM response JSON must be a list")
+
+    results: List[CodeLinkage] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+
+        artefact_id = str(item.get("artefact_id", "")).strip()
+        if not artefact_id:
+            continue
+
+        artefact_type_raw = str(item.get("artefact_type", "other"))
+        try:
+            artefact_type = ArtefactType(artefact_type_raw)
+        except ValueError:
+            artefact_type = ArtefactType.OTHER
+
+        relation_raw = str(item.get("relation", RelationType.OTHER.value))
+        try:
+            relation = RelationType(relation_raw)
+        except ValueError:
+            relation = RelationType.OTHER
+
+        comment_val = item.get("comment")
+        comment = str(comment_val).strip() if comment_val is not None else None
+        if comment == "":
+            comment = None
+
+        confidence_val = item.get("confidence")
+        confidence: Optional[float]
+        try:
+            confidence = float(confidence_val)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            confidence = None
+
+        results.append(
+            CodeLinkage(
+                artefact_id=artefact_id,
+                artefact_type=artefact_type,
+                relation=relation,
+                comment=comment,
+                confidence=confidence,
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# LLM backends
+# ---------------------------------------------------------------------------
+
+
+class LLMBackend(ABC):
+    """Abstract base class for LLM backends.
+
+    Implementations should:
+
+    - take raw paper text,
+    - run a prompt against an LLM,
+    - and return a list of :class:`CodeLinkage` instances.
+    """
+
+    @abstractmethod
+    def extract_linkages(self, paper_text: str) -> List[CodeLinkage]:
+        """Return code linkages for a given paper."""
+
+
+class TextCompletionBackend(LLMBackend):
+    """Backend that wraps a simple text-completion style interface.
+
+    Parameters
+    ----------
+    generator:
+        Callable that takes a prompt and returns a string response. This can be
+        backed by any provider (OpenAI, Anthropic, local LLM, etc.).
+    """
+
+    def __init__(self, generator: Callable[[str], str]) -> None:
+        self._generator = generator
+
+    def extract_linkages(self, paper_text: str) -> List[CodeLinkage]:
+        """Extract linkages by calling the generator with a structured prompt."""
+        prompt = _build_extraction_prompt(paper_text)
+        raw = self._generator(prompt)
+        return _parse_linkage_response(raw)
+
+
+class LiteLLMBackend(LLMBackend):
+    """Backend powered by `litellm <https://docs.litellm.ai/>`_.
+
+    ``litellm`` provides a unified interface to 100+ LLM providers.  Pass any
+    model string that ``litellm`` supports (e.g. ``"openai/gpt-4o"``,
+    ``"anthropic/claude-3.5-sonnet"``, ``"ollama/llama3"``).
+
+    Parameters
+    ----------
+    model:
+        The model identifier, following litellm naming conventions.
+    api_key:
+        Optional API key.  If *None*, litellm falls back to environment
+        variables (e.g. ``OPENAI_API_KEY``).
+    api_base:
+        Optional base URL, useful for self-hosted endpoints.
+    completion_kwargs:
+        Additional keyword arguments forwarded to ``litellm.completion``.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        completion_kwargs: Dict[str, Any] | None = None,
+    ) -> None:
+        self.model = model
+        self.api_key = api_key
+        self.api_base = api_base
+        self.completion_kwargs: Dict[str, Any] = completion_kwargs or {}
+
+    def extract_linkages(self, paper_text: str) -> List[CodeLinkage]:
+        """Extract linkages using a litellm-supported model."""
+        try:
+            import litellm  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise RuntimeError(
+                "The 'litellm' package is required for LiteLLMBackend. "
+                "Install it with: pip install litellm"
+            ) from exc
+
+        prompt = _build_extraction_prompt(paper_text)
+
+        kwargs: Dict[str, Any] = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            **self.completion_kwargs,
+        }
+        if self.api_key is not None:
+            kwargs["api_key"] = self.api_key
+        if self.api_base is not None:
+            kwargs["api_base"] = self.api_base
+
+        response = litellm.completion(**kwargs)
+        raw_text: str = response.choices[0].message.content  # type: ignore[union-attr]
+        return _parse_linkage_response(raw_text)
+
+
+class OpenAIBackend(LLMBackend):
+    """Example backend placeholder for OpenAI or compatible APIs.
+
+    This is intentionally left unimplemented so that this package does not
+    depend on any specific LLM provider.  You can implement this class in your
+    own codebase by calling the provider of your choice and returning
+    :class:`CodeLinkage` instances.
+    """
+
+    def extract_linkages(self, paper_text: str) -> List[CodeLinkage]:
+        """Raise ``NotImplementedError`` — implement in downstream code."""
+        raise NotImplementedError(
+            "OpenAIBackend is a placeholder. Implement it in your application "
+            "using your preferred OpenAI client and return `CodeLinkage` objects."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Paper text retrieval
+# ---------------------------------------------------------------------------
+
+# Regex patterns for identifier detection
+_DOI_RE = re.compile(r"^10\.\d{4,9}/[^\s]+$")
+_ZENODO_RE = re.compile(
+    r"https?://zenodo\.org/records?/(\d+)", re.IGNORECASE
+)
+
+
+def retrieve_paper_text(paper_identifier: str | Path) -> str:
+    """Resolve a paper identifier into plain text.
+
+    Supported identifiers (checked in order):
+
+    1. **Local file path** — if ``paper_identifier`` points to an existing file:
+       - ``.pdf`` files are read with ``pypdf`` (optional dependency).
+       - Everything else is read as UTF-8 text.
+    2. **Zenodo URL** (e.g. ``https://zenodo.org/records/12345``):
+       fetches record metadata via the Zenodo API, finds the first PDF file,
+       downloads it, and extracts text.
+    3. **DOI** (e.g. ``10.48550/arXiv.2307.09288``):
+       resolves via ``https://doi.org/<doi>``.  If the DOI leads to Zenodo the
+       Zenodo path is used; otherwise plain-text / HTML content is returned.
+    4. **Arbitrary HTTPS URL**: downloads the resource; PDF content-types are
+       extracted with ``pypdf``; HTML is stripped to text via ``BeautifulSoup``.
+    5. **Raw text** — if none of the above match, the string is returned as-is.
+    """
+    identifier = str(paper_identifier).strip()
+
+    # 1. Local file -------------------------------------------------------
+    path = Path(identifier)
+    if path.exists():
+        return _read_local_file(path)
+
+    # 2. Zenodo URL -------------------------------------------------------
+    zenodo_match = _ZENODO_RE.search(identifier)
+    if zenodo_match:
+        record_id = zenodo_match.group(1)
+        return _fetch_zenodo_record(record_id)
+
+    # 3. DOI --------------------------------------------------------------
+    if _DOI_RE.match(identifier):
+        return _resolve_doi(identifier)
+
+    # 4. Arbitrary URL ----------------------------------------------------
+    if identifier.startswith(("http://", "https://")):
+        return _fetch_url(identifier)
+
+    # 5. Raw text ---------------------------------------------------------
+    return identifier
+
+
+def _read_local_file(path: Path) -> str:
+    """Read a local file as text, using ``pypdf`` for PDFs."""
+    if path.suffix.lower() == ".pdf":
+        try:
+            import pypdf  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise RuntimeError(
+                "PDF support requires the optional 'pypdf' dependency. "
+                "Install it with `pip install pypdf`."
+            ) from exc
+
+        reader = pypdf.PdfReader(str(path))
+        texts: Iterable[str] = (
+            page.extract_text() or "" for page in reader.pages
+        )
+        return "\n\n".join(texts)
+
+    return path.read_text(encoding="utf-8")
+
+
+def _fetch_zenodo_record(record_id: str) -> str:
+    """Fetch the first PDF from a Zenodo record and extract its text."""
+    import requests  # already a project dependency
+
+    api_url = f"https://zenodo.org/api/records/{record_id}"
+    resp = requests.get(api_url, timeout=30)
+    resp.raise_for_status()
+    metadata = resp.json()
+
+    # Find the first PDF file in the record
+    pdf_url: str | None = None
+    for f in metadata.get("files", []):
+        if f.get("key", "").lower().endswith(".pdf"):
+            # Prefer the direct download link
+            pdf_url = f.get("links", {}).get("self")
+            if not pdf_url:
+                # Fallback: construct from bucket
+                pdf_url = f"https://zenodo.org/records/{record_id}/files/{f['key']}"
+            break
+
+    if pdf_url is None:
+        raise ValueError(
+            f"No PDF file found in Zenodo record {record_id}. "
+            "Please provide a direct PDF link or the paper text."
+        )
+
+    return _download_and_extract_pdf(pdf_url)
+
+
+def _resolve_doi(doi: str) -> str:
+    """Resolve a DOI to paper text.
+
+    If the DOI redirects to Zenodo, falls back to the Zenodo path.
+    Otherwise tries to fetch plain-text or HTML content.
+    """
+    import requests
+
+    doi_url = f"https://doi.org/{doi}"
+
+    # First, follow redirects to see where the DOI points
+    head_resp = requests.head(doi_url, allow_redirects=True, timeout=30)
+    final_url = head_resp.url
+
+    # If it redirects to Zenodo, use the Zenodo path
+    zenodo_match = _ZENODO_RE.search(final_url)
+    if zenodo_match:
+        return _fetch_zenodo_record(zenodo_match.group(1))
+
+    # Otherwise, try to fetch content
+    return _fetch_url(final_url)
+
+
+def _fetch_url(url: str) -> str:
+    """Download a URL and extract text.
+
+    - PDF content-types are processed with ``pypdf``.
+    - HTML is stripped to plain text with ``BeautifulSoup`` (optional dep).
+    - Everything else is returned as-is.
+    """
+    import requests
+
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+
+    content_type = resp.headers.get("Content-Type", "").lower()
+
+    if "application/pdf" in content_type or url.lower().endswith(".pdf"):
+        return _extract_pdf_from_bytes(resp.content)
+
+    if "text/html" in content_type:
+        return _html_to_text(resp.text)
+
+    # Fallback: plain text
+    return resp.text
+
+
+def _download_and_extract_pdf(url: str) -> str:
+    """Download a PDF from *url* and extract its text."""
+    import requests
+
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+    return _extract_pdf_from_bytes(resp.content)
+
+
+def _extract_pdf_from_bytes(pdf_bytes: bytes) -> str:
+    """Extract text from raw PDF bytes using ``pypdf``."""
+    import io
+
+    try:
+        import pypdf  # type: ignore[import-untyped]
+    except ImportError as exc:
+        raise RuntimeError(
+            "PDF support requires the optional 'pypdf' dependency. "
+            "Install it with `pip install pypdf`."
+        ) from exc
+
+    reader = pypdf.PdfReader(io.BytesIO(pdf_bytes))
+    texts: Iterable[str] = (
+        page.extract_text() or "" for page in reader.pages
+    )
+    return "\n\n".join(texts)
+
+
+def _html_to_text(html: str) -> str:
+    """Strip HTML tags and return plain text.
+
+    Uses ``BeautifulSoup`` if available, else falls back to a naive regex strip.
+    """
+    try:
+        from bs4 import BeautifulSoup  # type: ignore[import-untyped]
+
+        soup = BeautifulSoup(html, "html.parser")
+        return soup.get_text(separator="\n", strip=True)
+    except ImportError:
+        # Naive fallback: strip tags with regex
+        return re.sub(r"<[^>]+>", "", html)
+
+
+# ---------------------------------------------------------------------------
+# High-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def extract_linkages_from_paper(
+    paper_identifier: str | Path,
+    backend: Optional[LLMBackend] = None,
+) -> List[CodeLinkage]:
+    """Extract and classify code artefact linkages for a given paper.
+
+    Parameters
+    ----------
+    paper_identifier:
+        One of:
+
+        - local PDF path,
+        - local plain-text path,
+        - Zenodo URL (e.g. ``https://zenodo.org/records/12345``),
+        - DOI string (e.g. ``10.48550/arXiv.2307.09288``),
+        - arbitrary HTTPS URL,
+        - raw paper text (if it does not correspond to an existing file).
+
+    backend:
+        Implementation of :class:`LLMBackend`.  If omitted, you must provide
+        one yourself; this function does **not** assume a default service.
+
+    Returns
+    -------
+    list[CodeLinkage]
+        Structured linkages between the paper and code artefacts.
+    """
+    paper_text = retrieve_paper_text(paper_identifier)
+    if backend is None:
+        raise ValueError(
+            "No LLM backend provided. Pass an implementation of `LLMBackend`, "
+            "e.g. `TextCompletionBackend` or `LiteLLMBackend`."
+        )
+
+    return backend.extract_linkages(paper_text)
+
+
+def extract_linkages_from_text(
+    paper_text: str,
+    backend: LLMBackend,
+) -> List[CodeLinkage]:
+    """Convenience wrapper when you already have the paper text."""
+    return backend.extract_linkages(paper_text)

--- a/tests/test_linkage_extractor.py
+++ b/tests/test_linkage_extractor.py
@@ -1,0 +1,497 @@
+"""Tests for the publication-code linkage extractor.
+
+All tests use mocked HTTP responses and fake LLM generators — no real network
+calls or LLM API keys are required.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+
+from aiod.linkage_extractor import (
+    ArtefactType,
+    CodeLinkage,
+    LiteLLMBackend,
+    RelationType,
+    TextCompletionBackend,
+    _build_extraction_prompt,
+    _html_to_text,
+    _parse_linkage_response,
+    extract_linkages_from_paper,
+    extract_linkages_from_text,
+    retrieve_paper_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model tests
+# ---------------------------------------------------------------------------
+
+
+class TestRelationType:
+    def test_all_values_exist(self):
+        expected = {
+            "official_implementation",
+            "unofficial_implementation",
+            "code_used_in_experiments",
+            "code_cited_not_used",
+            "other",
+        }
+        assert {r.value for r in RelationType} == expected
+
+    def test_str_mixin(self):
+        assert RelationType.OFFICIAL_IMPLEMENTATION.value == "official_implementation"
+
+
+class TestArtefactType:
+    def test_all_values_exist(self):
+        expected = {"github_repository", "pypi_package", "other"}
+        assert {a.value for a in ArtefactType} == expected
+
+
+class TestCodeLinkage:
+    def test_construction_with_defaults(self):
+        link = CodeLinkage(
+            artefact_id="owner/repo",
+            artefact_type=ArtefactType.GITHUB_REPOSITORY,
+            relation=RelationType.OFFICIAL_IMPLEMENTATION,
+        )
+        assert link.artefact_id == "owner/repo"
+        assert link.comment is None
+        assert link.confidence is None
+
+    def test_construction_with_all_fields(self):
+        link = CodeLinkage(
+            artefact_id="numpy",
+            artefact_type=ArtefactType.PYPI_PACKAGE,
+            relation=RelationType.CODE_USED_IN_EXPERIMENTS,
+            comment="Used as main numerical library",
+            confidence=0.95,
+        )
+        assert link.confidence == 0.95
+        assert link.comment == "Used as main numerical library"
+
+
+# ---------------------------------------------------------------------------
+# Prompt / parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildExtractionPrompt:
+    def test_prompt_contains_instructions(self):
+        prompt = _build_extraction_prompt("Some paper text here.")
+        assert "scientific software discovery" in prompt
+        assert "official_implementation" in prompt
+        assert "JSON" in prompt
+        assert "Some paper text here." in prompt
+
+
+class TestParseResponse:
+    def test_valid_response(self):
+        data = [
+            {
+                "artefact_id": "owner/repo",
+                "artefact_type": "github_repository",
+                "relation": "official_implementation",
+                "comment": "Official code",
+                "confidence": 0.9,
+            },
+            {
+                "artefact_id": "numpy",
+                "artefact_type": "pypi_package",
+                "relation": "code_used_in_experiments",
+            },
+        ]
+        result = _parse_linkage_response(json.dumps(data))
+        assert len(result) == 2
+        assert result[0].artefact_id == "owner/repo"
+        assert result[0].artefact_type == ArtefactType.GITHUB_REPOSITORY
+        assert result[0].relation == RelationType.OFFICIAL_IMPLEMENTATION
+        assert result[0].confidence == 0.9
+        assert result[1].artefact_id == "numpy"
+        assert result[1].artefact_type == ArtefactType.PYPI_PACKAGE
+
+    def test_markdown_fenced_json(self):
+        """LLMs often wrap JSON in markdown code fences."""
+        inner = json.dumps([
+            {
+                "artefact_id": "pkg",
+                "artefact_type": "pypi_package",
+                "relation": "other",
+            }
+        ])
+        fenced = f"```json\n{inner}\n```"
+        result = _parse_linkage_response(fenced)
+        assert len(result) == 1
+        assert result[0].artefact_id == "pkg"
+
+    def test_malformed_json_raises(self):
+        with pytest.raises(ValueError, match="not valid JSON"):
+            _parse_linkage_response("this is not json")
+
+    def test_non_list_raises(self):
+        with pytest.raises(ValueError, match="must be a list"):
+            _parse_linkage_response('{"key": "value"}')
+
+    def test_skips_items_without_artefact_id(self):
+        data = [
+            {"artefact_type": "other", "relation": "other"},
+            {"artefact_id": "", "artefact_type": "other", "relation": "other"},
+            {
+                "artefact_id": "valid/repo",
+                "artefact_type": "github_repository",
+                "relation": "other",
+            },
+        ]
+        result = _parse_linkage_response(json.dumps(data))
+        assert len(result) == 1
+        assert result[0].artefact_id == "valid/repo"
+
+    def test_unknown_enum_values_fallback_to_other(self):
+        data = [
+            {
+                "artefact_id": "repo",
+                "artefact_type": "dockerhub_image",
+                "relation": "forked_from",
+            }
+        ]
+        result = _parse_linkage_response(json.dumps(data))
+        assert result[0].artefact_type == ArtefactType.OTHER
+        assert result[0].relation == RelationType.OTHER
+
+    def test_non_dict_items_skipped(self):
+        data = ["string_item", {"artefact_id": "ok", "relation": "other"}]
+        result = _parse_linkage_response(json.dumps(data))
+        assert len(result) == 1
+
+    def test_empty_comment_becomes_none(self):
+        data = [
+            {
+                "artefact_id": "repo",
+                "artefact_type": "other",
+                "relation": "other",
+                "comment": "",
+            }
+        ]
+        result = _parse_linkage_response(json.dumps(data))
+        assert result[0].comment is None
+
+
+# ---------------------------------------------------------------------------
+# Backend tests
+# ---------------------------------------------------------------------------
+
+
+class TestTextCompletionBackend:
+    def test_end_to_end(self):
+        fake_response = json.dumps([
+            {
+                "artefact_id": "scikit-learn/scikit-learn",
+                "artefact_type": "github_repository",
+                "relation": "code_used_in_experiments",
+                "comment": "ML library used for baselines",
+                "confidence": 0.85,
+            }
+        ])
+
+        def fake_generator(prompt: str) -> str:
+            assert "Paper text" in prompt or "scientific paper" in prompt
+            return fake_response
+
+        backend = TextCompletionBackend(generator=fake_generator)
+        linkages = backend.extract_linkages("Some paper text.")
+        assert len(linkages) == 1
+        assert linkages[0].artefact_id == "scikit-learn/scikit-learn"
+        assert linkages[0].relation == RelationType.CODE_USED_IN_EXPERIMENTS
+
+
+class TestLiteLLMBackend:
+    def test_import_error_gives_clear_message(self):
+        backend = LiteLLMBackend(model="openai/gpt-4o")
+        with patch.dict("sys.modules", {"litellm": None}):
+            with pytest.raises(RuntimeError, match="litellm"):
+                backend.extract_linkages("paper text")
+
+    def test_calls_litellm_completion(self):
+        mock_litellm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps([
+            {
+                "artefact_id": "torch",
+                "artefact_type": "pypi_package",
+                "relation": "code_used_in_experiments",
+            }
+        ])
+        mock_litellm.completion.return_value = mock_response
+
+        backend = LiteLLMBackend(
+            model="openai/gpt-4o",
+            api_key="test-key",
+        )
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            linkages = backend.extract_linkages("Paper about deep learning.")
+
+        assert len(linkages) == 1
+        assert linkages[0].artefact_id == "torch"
+        mock_litellm.completion.assert_called_once()
+        call_kwargs = mock_litellm.completion.call_args[1]
+        assert call_kwargs["model"] == "openai/gpt-4o"
+        assert call_kwargs["api_key"] == "test-key"
+
+
+# ---------------------------------------------------------------------------
+# Paper text retrieval tests
+# ---------------------------------------------------------------------------
+
+
+class TestRetrievePaperText:
+    def test_local_text_file(self, tmp_path: Path):
+        text_file = tmp_path / "paper.txt"
+        text_file.write_text("Hello, this is a paper.", encoding="utf-8")
+        result = retrieve_paper_text(str(text_file))
+        assert result == "Hello, this is a paper."
+
+    def test_raw_text_fallback(self):
+        raw = "This is raw paper text that is not a file path."
+        assert retrieve_paper_text(raw) == raw
+
+    @responses.activate
+    def test_zenodo_url(self):
+        record_id = "12345"
+        api_url = f"https://zenodo.org/api/records/{record_id}"
+
+        responses.add(
+            responses.GET,
+            api_url,
+            json={
+                "files": [
+                    {
+                        "key": "paper.pdf",
+                        "links": {"self": "https://zenodo.org/files/paper.pdf"},
+                    }
+                ]
+            },
+            status=200,
+        )
+
+        # Mock the PDF download — return minimal valid-ish bytes that will fail
+        # gracefully so we can test the flow up to PDF extraction
+        responses.add(
+            responses.GET,
+            "https://zenodo.org/files/paper.pdf",
+            body=b"fake-pdf-content",
+            status=200,
+        )
+
+        # pypdf will fail on fake bytes, but we can patch the extractor
+        with patch(
+            "aiod.linkage_extractor._extract_pdf_from_bytes",
+            return_value="Extracted paper text",
+        ):
+            result = retrieve_paper_text(f"https://zenodo.org/records/{record_id}")
+
+        assert result == "Extracted paper text"
+
+    @responses.activate
+    def test_zenodo_no_pdf_raises(self):
+        record_id = "99999"
+        api_url = f"https://zenodo.org/api/records/{record_id}"
+
+        responses.add(
+            responses.GET,
+            api_url,
+            json={"files": [{"key": "data.csv"}]},
+            status=200,
+        )
+
+        with pytest.raises(ValueError, match="No PDF file found"):
+            retrieve_paper_text(f"https://zenodo.org/records/{record_id}")
+
+    @responses.activate
+    def test_doi_redirects_to_zenodo(self):
+        doi = "10.5281/zenodo.12345"
+        doi_url = f"https://doi.org/{doi}"
+
+        # HEAD request follows redirect to Zenodo
+        responses.add(
+            responses.HEAD,
+            doi_url,
+            status=302,
+            headers={"Location": "https://zenodo.org/records/12345"},
+        )
+        responses.add(
+            responses.HEAD,
+            "https://zenodo.org/records/12345",
+            status=200,
+        )
+
+        # Mock the Zenodo API + PDF extraction
+        responses.add(
+            responses.GET,
+            "https://zenodo.org/api/records/12345",
+            json={
+                "files": [
+                    {
+                        "key": "paper.pdf",
+                        "links": {"self": "https://zenodo.org/files/paper.pdf"},
+                    }
+                ]
+            },
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            "https://zenodo.org/files/paper.pdf",
+            body=b"fake-pdf",
+            status=200,
+        )
+
+        with patch(
+            "aiod.linkage_extractor._extract_pdf_from_bytes",
+            return_value="DOI paper text",
+        ):
+            result = retrieve_paper_text(doi)
+
+        assert result == "DOI paper text"
+
+    @responses.activate
+    def test_arbitrary_html_url(self):
+        url = "https://example.com/paper.html"
+
+        responses.add(
+            responses.GET,
+            url,
+            body="<html><body><h1>Title</h1><p>Content here.</p></body></html>",
+            status=200,
+            content_type="text/html",
+        )
+
+        result = retrieve_paper_text(url)
+        assert "Title" in result
+        assert "Content here" in result
+
+
+class TestHtmlToText:
+    def test_strips_tags_with_bs4(self):
+        html = "<html><body><h1>Hello</h1><p>World</p></body></html>"
+        result = _html_to_text(html)
+        assert "Hello" in result
+        assert "World" in result
+        assert "<" not in result
+
+    def test_regex_fallback(self):
+        html = "<b>Bold</b> and <i>italic</i>"
+        with patch.dict("sys.modules", {"bs4": None}):
+            # Force ImportError to test regex fallback
+            with patch(
+                "aiod.linkage_extractor._html_to_text",
+                wraps=lambda h: __import__("re").sub(r"<[^>]+>", "", h),
+            ):
+                import re
+                result = re.sub(r"<[^>]+>", "", html)
+                assert result == "Bold and italic"
+
+
+# ---------------------------------------------------------------------------
+# Orchestration tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLinkagesFromPaper:
+    def test_raises_without_backend(self):
+        with pytest.raises(ValueError, match="No LLM backend"):
+            extract_linkages_from_paper("some text")
+
+    def test_end_to_end_with_mock(self):
+        fake_json = json.dumps([
+            {
+                "artefact_id": "pandas-dev/pandas",
+                "artefact_type": "github_repository",
+                "relation": "code_used_in_experiments",
+            }
+        ])
+        backend = TextCompletionBackend(generator=lambda _: fake_json)
+        linkages = extract_linkages_from_paper("paper text", backend=backend)
+        assert len(linkages) == 1
+        assert linkages[0].artefact_id == "pandas-dev/pandas"
+
+
+class TestExtractLinkagesFromText:
+    def test_convenience_wrapper(self):
+        fake_json = json.dumps([
+            {
+                "artefact_id": "scipy",
+                "artefact_type": "pypi_package",
+                "relation": "code_cited_not_used",
+            }
+        ])
+        backend = TextCompletionBackend(generator=lambda _: fake_json)
+        linkages = extract_linkages_from_text("paper text", backend)
+        assert len(linkages) == 1
+        assert linkages[0].relation == RelationType.CODE_CITED_NOT_USED
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_json_output(self, capsys: pytest.CaptureFixture[str]):
+        from aiod.linkage_cli import _format_json
+
+        linkages = [
+            CodeLinkage(
+                artefact_id="owner/repo",
+                artefact_type=ArtefactType.GITHUB_REPOSITORY,
+                relation=RelationType.OFFICIAL_IMPLEMENTATION,
+                comment="Official repo",
+                confidence=0.95,
+            )
+        ]
+        output = _format_json(linkages)
+        parsed = json.loads(output)
+        assert len(parsed) == 1
+        assert parsed[0]["artefact_id"] == "owner/repo"
+        assert parsed[0]["artefact_type"] == "github_repository"
+
+    def test_table_output(self):
+        from aiod.linkage_cli import _format_table
+
+        linkages = [
+            CodeLinkage(
+                artefact_id="torch",
+                artefact_type=ArtefactType.PYPI_PACKAGE,
+                relation=RelationType.CODE_USED_IN_EXPERIMENTS,
+            )
+        ]
+        table = _format_table(linkages)
+        assert "torch" in table
+        assert "pypi_package" in table
+        assert "code_used_in_experiments" in table
+
+    def test_table_empty(self):
+        from aiod.linkage_cli import _format_table
+
+        assert _format_table([]) == "No linkages found."
+
+    def test_build_parser(self):
+        from aiod.linkage_cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "paper.pdf",
+            "--model", "openai/gpt-4o",
+            "--output", "json",
+        ])
+        assert args.paper == "paper.pdf"
+        assert args.model == "openai/gpt-4o"
+        assert args.output == "json"


### PR DESCRIPTION
## Change

This PR implements a backend-independent LLM-based utility to automatically generate linkages between scientific publications (DOI / Zenodo / PDF) and related software artefacts.

The utility identifies and categorizes related GitHub repositories and PyPI packages into:

- Official implementations
- Unofficial implementations
- Code used in experiments
- Cited but not directly related

The implementation is backend-agnostic through a base LLM interface, allowing easy switching or upgrading of LLM providers without modifying core logic.

New components introduced:
- src/aiod/linkage_extractor.py – core extraction and classification logic
- src/aiod/linkage_cli.py – CLI interface
- tests/test_linkage_extractor.py – structured output and validation tests

---

## How to Test

1. Install dependencies
2. Run:
   pytest tests/test_linkage_extractor.py

Optional CLI test:
   python -m aiod.linkage_cli --doi <DOI>

Expected output: structured JSON containing categorized artefact linkages.

---

## Design Notes

- Backend-independent LLM abstraction layer
- Structured JSON output for deterministic downstream use
- Clear separation between extraction logic and CLI layer
- Designed for future extension (ranking, validation layers, additional categories)

---

## Checklist

- [x] Tests added
- [x] Documentation updated (where applicable)
- [x] Self-review completed
- [ ] CI passing (to be verified after submission)

---

Closes #104