### PR TITLE
[DOC] Update Python version badge to reflect actual requirement (3.10+)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![python](https://img.shields.io/badge/Python-3.11-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+[![python](https://img.shields.io/badge/Python-3.10+-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
 
 # Connect to [AI-on-Demand](https://aiod.eu) in Python.
 


### PR DESCRIPTION
## Change
Updated Python version badge in `docs/README.md` to accurately reflect the minimum supported Python version specified in `pyproject.toml`.

**Issue:**
- Badge displayed "Python 3.11"
- `pyproject.toml` specifies `requires-python = ">=3.10"`
- This could mislead users with Python 3.10 into thinking the package isn't compatible with their version

**Before:**
```markdown
[![python](https://img.shields.io/badge/Python-3.11-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
```

**After:**
```markdown
[![python](https://img.shields.io/badge/Python-3.10+-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
```

## How to Test
1. View the rendered README documentation
2. Verify the Python badge displays "Python 3.10+"
3. Confirm this matches the requirement in `pyproject.toml`: `requires-python = ">=3.10"`

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
  - No tests needed - this is a documentation badge update only
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
  - This PR corrects the documentation badge to match actual requirements
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.
  - Documentation-only change, no CI impact expected

## Related Issues
Found during documentation review as ESOC 2026 contributor. This ensures the badge accurately represents the minimum Python version requirement defined in the project configuration.

---