### PR TITLE
Fix token file permissions

### DIFF
--- a/src/aiod/authentication/authentication.py
+++ b/src/aiod/authentication/authentication.py
@@ -1,6 +1,7 @@
 import functools
 import http.client
 import logging
+import os
 import time
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
@@ -125,6 +126,14 @@ class Token:
         file = file or _user_token_file
         file.parent.mkdir(parents=True, exist_ok=True)
         file.write_text(tomlkit.dumps(doc))
+
+        try:
+            os.chmod(file, 0o600)
+        except (OSError, NotImplementedError):
+            logger.warning(
+                f"Could not set restrictive permissions on {file}. "
+                "Ensure the file is not accessible to other users."
+            )
 
     @classmethod
     def from_file(cls, file: Path | None = None) -> "Token":


### PR DESCRIPTION
=

🔐 Secure Token File Permissions (Fixes #137)

Summary
This PR fixes #137 by securing the permissions of the generated ~/.aiod/token.toml file.
Previously, the file was created with default system permissions (often 0o644), making sensitive credentials like access_token and refresh_token potentially world-readable on Unix-like systems.

The update explicitly sets file permissions to 0o600 (owner read/write only) using os.chmod.

Changes
	•	Imported os in authentication.py
	•	Applied os.chmod(file, 0o600) after writing the token file
	•	Wrapped chmod in try/except to handle non-POSIX systems gracefully (logs warning instead of failing)

Type of Change
	•	Security fix
	•	Bug fix
	•	Breaking change

Testing
	•	Verified aiod.create_token().to_file() creates ~/.aiod/token.toml
	•	Confirmed permissions are set to -rw------- (0o600) on Unix-like systems

⸻
