### PR TITLE
[ENH] Catalogues for Curated Collection of Resources

### DIFF
--- a/src/aiod/catalogues/__init__.py
+++ b/src/aiod/catalogues/__init__.py
@@ -1,0 +1,6 @@
+"""Collections of estimators, datasets, metrics, and mixed obj types."""
+
+from aiod.catalogues.base import BaseCatalogue
+from aiod.catalogues.classification import DummyClassificationCatalogue
+
+__all__ = ["BaseCatalogue", "DummyClassificationCatalogue"]

--- a/src/aiod/catalogues/base/__init__.py
+++ b/src/aiod/catalogues/base/__init__.py
@@ -1,0 +1,5 @@
+"""Base class for catalogues."""
+
+__all__ = ["BaseCatalogue"]
+
+from aiod.catalogues.base._base import BaseCatalogue

--- a/src/aiod/catalogues/base/_base.py
+++ b/src/aiod/catalogues/base/_base.py
@@ -1,0 +1,141 @@
+"""Base class for Catalogues."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any
+
+import aiod
+from aiod.base import _BasePkg
+
+__all__ = ["BaseCatalogue"]
+
+
+class BaseCatalogue(_BasePkg):
+    """Base class for catalogue objects.
+
+    A catalogue stores collections of object specifications grouped by category.
+    Subclasses implement `_fetch`, which defines the available items.
+
+    Items can be returned either as:
+    - specification strings (default), or
+    - instantiated objects (via `craft`), if `as_object=True`.
+    """
+
+    _tags: dict[str, Any] = {
+        "authors": ["aiod developers"],
+        "maintainers": ["aiod developers"],
+        "object_type": "catalogue",
+        "catalogue_type": None,
+        "n_items": None,
+        "info:name": "",
+        "info:description": "",
+        "info:source": "",  # DOI
+    }
+
+    def __init__(self) -> None:
+        """Initialize the catalogue with an empty object cache."""
+        super().__init__()
+        self._cached_objects: dict[str, list[Any]] | None = None
+
+    @abstractmethod
+    def _fetch(self) -> dict[str, list[str | Any]]:
+        """Return the default items for this catalogue.
+
+        Returns
+        -------
+        dict[str, list[str | Any]]
+            Dictionary mapping category names to lists of items.
+            Items may be specification strings or pre-instantiated objects.
+        """
+        ...
+
+    def fetch(
+        self,
+        object_type: str = "all",
+        as_object: bool = False,
+    ) -> list[str | Any]:
+        """Retrieve items from the catalogue.
+
+        Parameters
+        ----------
+        object_type : str, default="all"
+            Category of objects to retrieve.
+
+            - "all": return items from all categories.
+            - Otherwise: must match one of `available_categories()`.
+
+        as_object : bool, default=False
+            If True, return instantiated objects.
+            If False, return specification strings or object names.
+
+        Returns
+        -------
+        list[str] or list[Any]
+            List of specification names (default) or instantiated objects.
+        """
+        names_dict = self._fetch()
+
+        if object_type != "all" and object_type not in names_dict:
+            raise KeyError(
+                f"Invalid object_type '{object_type}'. "
+                f"Available keys: {list(names_dict.keys())}"
+            )
+
+        items: list[str | Any] = (
+            [item for sublist in names_dict.values() for item in sublist]
+            if object_type == "all"
+            else names_dict[object_type]
+        )
+
+        if not as_object:
+            return [
+                item
+                if isinstance(item, str)
+                else (item.__name__ if callable(item) else type(item).__name__)
+                for item in items
+            ]
+
+        # as_object=True
+        if self._cached_objects is None:
+            self._cached_objects = {}
+
+        if object_type not in self._cached_objects:
+            processed: list[Any] = []
+            for item in items:
+                if isinstance(item, str):
+                    processed.append(aiod.get(item))
+                else:
+                    processed.append(item)
+            self._cached_objects[object_type] = processed
+
+        return self._cached_objects[object_type]
+
+    def available_categories(self) -> list[str]:
+        """Return available item categories in the catalogue.
+
+        Returns
+        -------
+        list[str]
+            Category names defined by `_fetch()`.
+        """
+        return list(self._fetch().keys())
+
+    def __len__(self) -> int:
+        """Return total number of items across all categories."""
+        return len(self.fetch("all"))
+
+    def __contains__(self, name: str) -> bool:
+        """Check whether a specification name exists in the catalogue.
+
+        Parameters
+        ----------
+        name : str
+            Specification string to check.
+
+        Returns
+        -------
+        bool
+            True if present, False otherwise.
+        """
+        return name in self.fetch("all")

--- a/src/aiod/catalogues/classification/__init__.py
+++ b/src/aiod/catalogues/classification/__init__.py
@@ -1,0 +1,5 @@
+"""Classification catalogues."""
+
+from aiod.catalogues.classification.dummy import DummyClassificationCatalogue
+
+__all__ = ["DummyClassificationCatalogue"]

--- a/src/aiod/catalogues/classification/dummy/__init__.py
+++ b/src/aiod/catalogues/classification/dummy/__init__.py
@@ -1,0 +1,5 @@
+"""Dummy classification catalogue."""
+
+from aiod.catalogues.classification.dummy._dummy import DummyClassificationCatalogue
+
+_all__ = ["DummyClassificationCatalogue"]

--- a/src/aiod/catalogues/classification/dummy/_dummy.py
+++ b/src/aiod/catalogues/classification/dummy/_dummy.py
@@ -1,0 +1,48 @@
+"""Dummy classification catalogue."""
+
+from __future__ import annotations
+
+__all__ = ["DummyClassificationCatalogue"]
+
+from typing import Any
+
+from aiod.catalogues.base import BaseCatalogue
+
+
+class DummyClassificationCatalogue(BaseCatalogue):
+    """Dummy catalogue of classification components.
+
+    This catalogue provides example classifier specifications
+    for testing and demonstration purposes.
+    """
+
+    _tags: dict[str, Any] = {
+        "authors": ["jgyasu"],
+        "maintainers": ["jgyasu"],
+        "object_type": "catalogue",
+        "catalogue_type": "mixed",
+        "n_items": 5,
+        "n_classifiers": 5,
+        "python_dependencies": ["scikit-learn"],
+    }
+
+    def _fetch(self) -> dict[str, list[str | Any]]:
+        """Return classifier specifications grouped by category.
+
+        Returns
+        -------
+        dict[str, list[str]]
+            Dictionary with a single category `"classifier"`,
+            containing sklearn classifier specification strings.
+        """
+        classifiers: list[str] = [
+            "LogisticRegression(max_iter=1000)",
+            "RandomForestClassifier(n_estimators=100)",
+            "RandomForestClassifier(n_estimators=200)",
+            "SVC()",
+            "KNeighborsClassifier(n_neighbors=5)",
+        ]
+
+        return {
+            "classifier": classifiers,
+        }

--- a/src/aiod/catalogues/tests/__init__.py
+++ b/src/aiod/catalogues/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for catalogues module."""

--- a/src/aiod/catalogues/tests/test_base.py
+++ b/src/aiod/catalogues/tests/test_base.py
@@ -1,0 +1,61 @@
+"""Unit tests for the BaseCatalogue class."""
+
+import pytest
+
+from aiod.catalogues.base import BaseCatalogue
+
+
+class DummyCatalogue(BaseCatalogue):
+    """Minimal subclass for testing BaseCatalogue behavior."""
+
+    def _fetch(self):
+        return {
+            "classifier": ["KNeighborsClassifier(n_neighbors=5)"],
+        }
+
+
+@pytest.fixture
+def dummy_catalogue():
+    """Fixture returning a minimal dummy catalogue."""
+    return DummyCatalogue()
+
+
+def test_available_categories(dummy_catalogue):
+    """available_categories should return keys from _fetch()."""
+    assert set(dummy_catalogue.available_categories()) == {"classifier"}
+
+
+def test_fetch_all_and_specific(dummy_catalogue):
+    """fetch() should flatten correctly and handle category filters."""
+    all_items = dummy_catalogue.fetch("all")
+    assert isinstance(all_items, list)
+    assert set(all_items) == {"KNeighborsClassifier(n_neighbors=5)"}
+
+    classifier = dummy_catalogue.fetch("classifier")
+    assert classifier == ["KNeighborsClassifier(n_neighbors=5)"]
+
+
+def test_fetch_invalid_type(dummy_catalogue):
+    """Invalid object_type should raise KeyError."""
+    with pytest.raises(KeyError):
+        dummy_catalogue.fetch("invalid")
+
+
+def test_fetch_as_string(dummy_catalogue):
+    """fetch() with as_object=False should return list of string specs."""
+    items_as_string = dummy_catalogue.fetch("all", as_object=False)
+    assert all(isinstance(item, str) for item in items_as_string)
+
+
+def test_fetch_as_object(dummy_catalogue):
+    """fetch() with as_object=True should return instantiated objects."""
+    items_as_object = dummy_catalogue.fetch("all", as_object=True)
+    assert all(not isinstance(item, str) for item in items_as_object)
+    assert items_as_object[0].__class__.__name__ == "KNeighborsClassifier"
+
+
+def test_len_and_contains(dummy_catalogue):
+    """__len__ and __contains__ should behave correctly."""
+    assert len(dummy_catalogue) == 1
+    assert "KNeighborsClassifier(n_neighbors=5)" in dummy_catalogue
+    assert "LogisticRegression()" not in dummy_catalogue


### PR DESCRIPTION
This PR introduces the `BaseCatalogue` abstraction and a concrete `DummyClassificationCatalogue` implementation to formalize how collections of reusable components (e.g., classifiers, datasets, metrics) are defined and accessed. A catalogue exposes grouped specification strings via `_fetch()` and provides a unified `fetch()` interface that can return either string specifications or instantiated objects.

To check an example and understand the use case, please checkout the design mock-ups notebook in #64 