### PR TITLE
Fix for issuse #147

### DIFF
--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -239,7 +239,7 @@ def post_asset(
     asset_type: str,
     metadata: dict,
     version: str | None = None,
-) -> str | requests.Response:
+) -> str:
     """Register ASSET_TYPE in catalogue.
 
     All parameters must be specified by name.
@@ -254,9 +254,12 @@ def post_asset(
     Returns
     -------
     identifier: str
-        if the asset is registered successfully
-    error response: requests.Response
-        error response, if it failed to register successfully
+        The identifier of the newly registered asset.
+
+    Raises
+    ------
+    ServerError
+        If the server returns a non-OK response.
     """
     url = f"{server_url(version)}{asset_type}"
     res = requests.post(
@@ -267,7 +270,7 @@ def post_asset(
     )
     if res.status_code == HTTPStatus.OK:
         return res.json()["identifier"]
-    return res
+    raise ServerError(res)
 
 
 def counts(*, asset_type: str, version: str | None = None, per_platform: bool = False) -> int | dict[str, int]:

--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -198,6 +198,11 @@ def patch_asset(
     -----
     This is a best-effort implementation, but is not yet officially supported by the server.
 
+    .. warning::
+        This operation is **not atomic**. It internally performs a GET followed by a PUT,
+        so concurrent edits by another client between those two calls will be silently
+        overwritten. For critical updates, use `put_asset` with a complete metadata payload.
+
     Parameters
     ----------
     identifier

--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -99,6 +99,8 @@ def get_list(
         url,
         timeout=config.request_timeout_seconds,
     )
+    if res.status_code != HTTPStatus.OK:
+        raise ServerError(res)
     resources = format_response(res.json(), data_format)
     return resources
 
@@ -464,6 +466,8 @@ def search(
         url,
         timeout=config.request_timeout_seconds,
     )
+    if res.status_code != HTTPStatus.OK:
+        raise ServerError(res)
     resources = format_response(res.json()["resources"], data_format)
     return resources
 


### PR DESCRIPTION
## Fix: Error Handling Inconsistencies  
Closes: https://github.com/aiondemand/aiondemand/issues/147

Resolved three inconsistencies in error handling within `src/aiod/calls/calls.py` to ensure uniform API behavior across the module.

---

### 1. `patch_asset`

- Docstring updated with explicit `.. warning::`
- Clarifies that the operation is **non-atomic**
- Internally performs a `GET + PUT`
- Concurrent edits may be silently overwritten

---

### 2. `get_list` and `search`

- Added `ServerError` raise on non-2xx HTTP responses
- Now consistent with all other read/write operations in the file
- Prevents unreadable `JSONDecodeError` on server failures

---

### 3. `post_asset`

- Now raises `ServerError` on failure instead of returning a raw `requests.Response`
- Return type simplified from:

  ```python
  str | requests.Response
  ```

  to:

  ```python
  str
  ```

- Ensures consistent return contract
- Removes need for `isinstance` checks

---

These changes align error handling, improve API predictability, and reduce hidden failure modes.
<img width="1305" height="420" alt="image" src="https://github.com/user-attachments/assets/a11a9252-044b-449f-8945-603cff091636" />
all test passed .