### PR TITLE
fix: resolve three silent error bugs

### DIFF
--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -290,6 +290,8 @@ def counts(*, asset_type: str, version: str | None = None, per_platform: bool = 
     """
     url = url_to_resource_counts(version, per_platform, asset_type)
     res = requests.get(url, timeout=config.request_timeout_seconds)
+    if res.status_code != HTTPStatus.OK:
+        raise ServerError(res)
     return res.json()
 
 

--- a/src/aiod/calls/utils.py
+++ b/src/aiod/calls/utils.py
@@ -28,10 +28,12 @@ def format_response(response: list | dict, data_format: Literal["pandas", "json"
             return pd.Series(response)
         if isinstance(response, list):
             return pd.DataFrame(response)
-    elif data_format == "json" and (isinstance(response, dict) or isinstance(response, list)):
+    elif data_format == "json" and isinstance(response, (dict, list)):
         return response
 
-    raise Exception(f"Format: {data_format} invalid or not supported for responses of {type(response)=}.")
+    raise ValueError(
+        f"Unsupported data_format {data_format!r}. Expected 'pandas' or 'json'."
+    )
 
 
 def wrap_calls(asset_type: str, calls: list[Callable], module: str) -> tuple[Callable, ...]:
@@ -60,3 +62,4 @@ class ServerError(RuntimeError):
         self.detail = response.json().get("detail")
         self.reference = response.json().get("reference")
         self._response = response
+        super().__init__(f"[{self.status_code}] {self.detail}")


### PR DESCRIPTION
## Fix Summary https://github.com/aiondemand/aiondemand/issues/155

| Fix | File | Change |
|-----|------|--------|
| `ServerError.__str__` | `calls/utils.py` | Added `super().__init__(f"[{status_code}] {detail}")` |
| `counts()` status check | `calls/calls.py` | Raises `ServerError` on non-OK response |
| `format_response` error type | `calls/utils.py` | `Exception` → `ValueError` with cleaner message |
<img width="1019" height="364" alt="image" src="https://github.com/user-attachments/assets/f929b343-e5d8-446d-b723-dc5e0c5dac79" />
