### PR TITLE
Temporarily disable server-based integration tests in CI (AIoD API down)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,12 @@ jobs:
         name: Run local tests
       - run: python -m pytest src/aiod
         name: Run tests in package
-      - run: python -m pytest -m server tests
-        name: Run integration tests
+      # Temporarily disabled: AIoD API is currently not responding
+      # See issue: https://github.com/aiondemand/AIOD-rest-api/issues/717
+      # These integration tests depend on the live server and
+      # are causing CI to fail. Re-enable once the API is back up and stable.
+      # - run: python -m pytest -m server tests
+      #   name: Run integration tests
 
   code-quality:
     name: code-quality


### PR DESCRIPTION
This PR temporarily disables the `server` marked integration tests in the CI workflow.

The AIoD API is currently not responding (see https://github.com/aiondemand/AIOD-rest-api/issues/717), which causes all CI runs to fail due to the integration tests depending on the live server.

Changes in this PR:

* Comment out `pytest -m server tests` in `.github/workflows/tests.yml`
* Keep all local and package tests (`pytest tests`, `pytest src/aiod`) running as before

This is intended as a temporary measure. Once the API is back up and stable (or the migration is completed), the integration tests should be re-enabled.
