### PR TITLE
fix: correct `distribution_idx=0` falsy check and `timedelta.seconds` precision loss

### DIFF
--- a/src/aiod/authentication/authentication.py
+++ b/src/aiod/authentication/authentication.py
@@ -141,7 +141,7 @@ class Token:
                 kwargs.update(
                     {
                         "access_token": str(doc["access_token"]),
-                        "expires_in_seconds": expires_in.seconds,
+                        "expires_in_seconds": int(expires_in.total_seconds()),
                     }
                 )
         return Token(**kwargs)  # type: ignore[arg-type]

--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -58,7 +58,7 @@ def url_to_get_content(
 ) -> str:
     base_url = server_url(version)
     url = f"{base_url}{asset_type}/{identifier}/content"
-    url += f"/{distribution_idx}" if distribution_idx else ""
+    url += f"/{distribution_idx}" if distribution_idx is not None else ""
     return url
 
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -183,3 +183,24 @@ def test_token_to_file_creates_parent_directory(tmp_path):
     # Calling it multiple times should not result in an error,
     # even if the directory or file already exist.
     token.to_file(token_file)
+
+
+def test_token_from_file_preserves_long_expiry(tmp_path):
+    """Regression: Token.from_file must preserve expiry durations longer than 24 hours.
+
+    Previously, `timedelta.seconds` was used instead of `timedelta.total_seconds()`,
+    which wraps around at 86400 and loses the days component.
+    """
+    token_file = tmp_path / "token.toml"
+    # A token that expires in ~2 days (172800 seconds)
+    token = Token(
+        refresh_token="long_lived",
+        access_token="valid_access",
+        expires_in_seconds=172800,
+    )
+    token.to_file(token_file)
+
+    restored = Token.from_file(token_file)
+    # The restored token should NOT have expired (it has ~2 days left)
+    assert not restored.has_expired
+    assert restored._access_token == "valid_access"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -176,12 +176,29 @@ def test_get_content(asset_name):
             res_body = f.read()
         mocked_requests.add(
             responses.GET,
-            f"{server_url()}{asset_name}/1/content",
+            f"{server_url()}{asset_name}/1/content/0",
             body=res_body,
             status=200,
         )
         endpoint = getattr(aiod, asset_name)
         content = endpoint.get_content(identifier=1)
+
+        assert content == b"a,b,c\n1,2,3"
+
+
+def test_get_content_with_distribution_idx_zero(asset_name):
+    """Regression test: distribution_idx=0 must append '/0' to the URL."""
+    with responses.RequestsMock() as mocked_requests:
+        with open(resources_path / "content.csv", "r") as f:
+            res_body = f.read()
+        mocked_requests.add(
+            responses.GET,
+            f"{server_url()}{asset_name}/1/content/0",
+            body=res_body,
+            status=200,
+        )
+        endpoint = getattr(aiod, asset_name)
+        content = endpoint.get_content(identifier=1, distribution_idx=0)
 
         assert content == b"a,b,c\n1,2,3"
 
@@ -200,6 +217,7 @@ def test_get_content_with_distribution_idx(asset_name):
         content = endpoint.get_content(identifier=1, distribution_idx=2)
 
         assert content == b"a,b,c\n1,2,3"
+
 
 
 def test_search(asset_with_search):


### PR DESCRIPTION
## Fix Summary

This PR fixes two independent correctness bugs discovered during a codebase audit.

---

### Bug 1: `distribution_idx=0` silently dropped from content URL

**File:** [src/aiod/calls/urls.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/aiondemand/src/aiod/calls/urls.py:0:0-0:0) (line 61)

**Problem:** The URL construction for [get_content](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/aiondemand/src/aiod/calls/calls.py:375:0-406:23) used a truthiness check:
```python
url += f"/{distribution_idx}" if distribution_idx else ""
```
When `distribution_idx=0` (the **default value**), `0` is falsy in Python, so `/0` was never appended to the URL. This means requesting the first distribution produced an incorrect URL path.

**Fix:** Changed to an explicit identity check:
```python
url += f"/{distribution_idx}" if distribution_idx is not None else ""
```

**Tests:**
- Updated [test_get_content](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/aiondemand/tests/test_endpoints.py:172:0-185:41) to expect the corrected URL with `/0`
- Added [test_get_content_with_distribution_idx_zero](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/aiondemand/tests/test_endpoints.py:188:0-202:41) as a regression test

---

### Bug 2: `timedelta.seconds` loses hours/days in `Token.from_file()`

**File:** [src/aiod/authentication/authentication.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/aiondemand/src/aiod/authentication/authentication.py:0:0-0:0) (line 144)

**Problem:** When restoring a token from file, the code used:
```python
"expires_in_seconds": expires_in.seconds
```
`timedelta.seconds` returns only the **seconds component** (0–86399), discarding the days. A token expiring in 1 day + 30 seconds would report `expires_in_seconds=30`, causing a premature refresh.

**Fix:**
```python
"expires_in_seconds": int(expires_in.total_seconds())
```

**Tests:**
- Added [test_token_from_file_preserves_long_expiry](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/aiondemand/tests/test_authentication.py:187:0-205:51) — round-trips a token with a 2-day expiry and asserts it is not marked as expired after deserialization.

---

### Verification

<img width="1919" height="317" alt="image" src="https://github.com/user-attachments/assets/50b8f44a-1646-40eb-8ba7-e133cea906cd" />

<img width="1919" height="255" alt="image" src="https://github.com/user-attachments/assets/ef89e388-b72a-4db9-bc71-0f1ed2d7890e" />

<img width="1919" height="713" alt="image" src="https://github.com/user-attachments/assets/b9746418-4ba1-4603-853b-614dfcdc6a1c" />

All tests are passing .


