### PR TITLE
fix: handle non-JSON responses in ServerError.__init__

### DIFF
--- a/src/aiod/calls/utils.py
+++ b/src/aiod/calls/utils.py
@@ -6,14 +6,18 @@ import pandas as pd
 import requests
 
 
-def format_response(response: list | dict, data_format: Literal["pandas", "json"]) -> pd.Series | pd.DataFrame | dict | list:
+def format_response(
+    response: list | dict,
+    data_format: Literal["pandas", "json"],
+) -> pd.Series | pd.DataFrame | dict | list:
     """Format the response data based on the specified format.
 
     Parameters
     ----------
         response (list | dict): The response data to format.
-        data_format (Literal["pandas", "json"]): The desired format for the response.
-            For "json" formats, the returned type is a json decoded type, i.e. a dict or a list.
+        data_format (Literal["pandas", "json"]): The desired output format.
+            For "json" formats, the returned type is a json decoded type,
+            i.e. a dict or a list.
 
     Returns
     -------
@@ -28,18 +32,31 @@ def format_response(response: list | dict, data_format: Literal["pandas", "json"
             return pd.Series(response)
         if isinstance(response, list):
             return pd.DataFrame(response)
-    elif data_format == "json" and (isinstance(response, dict) or isinstance(response, list)):
+    elif data_format == "json" and (
+        isinstance(response, dict) or isinstance(response, list)
+    ):
         return response
 
-    raise Exception(f"Format: {data_format} invalid or not supported for responses of {type(response)=}.")
+    raise Exception(
+        f"Format: {data_format} invalid or not supported for"
+        f" responses of {type(response)=}."
+    )
 
 
-def wrap_calls(asset_type: str, calls: list[Callable], module: str) -> tuple[Callable, ...]:
+def wrap_calls(
+    asset_type: str,
+    calls: list[Callable],
+    module: str,
+) -> tuple[Callable, ...]:
     wrapper_list = []
     for wrapped in calls:
         wrapper: Callable = partial(wrapped, asset_type=asset_type)
         wrapper = update_wrapper(wrapper, wrapped)
-        wrapper.__doc__ = wrapped.__doc__.replace("ASSET_TYPE", asset_type) if wrapped.__doc__ is not None else ""
+        wrapper.__doc__ = (
+            wrapped.__doc__.replace("ASSET_TYPE", asset_type)
+            if wrapped.__doc__ is not None
+            else ""
+        )
         wrapper.__module__ = module
         wrapper_list.append(wrapper)
 
@@ -53,10 +70,16 @@ class EndpointUndefinedError(Exception):
 
 
 class ServerError(RuntimeError):
-    """Raised for any server error that does not (yet) have better client-side handling."""
+    """Raised for server errors without better client-side handling."""
 
     def __init__(self, response: requests.Response):
         self.status_code = response.status_code
-        self.detail = response.json().get("detail")
-        self.reference = response.json().get("reference")
+        try:
+            body = response.json()
+        except (ValueError, requests.exceptions.JSONDecodeError):
+            body = {}
+        self.detail = body.get("detail")
+        self.reference = body.get("reference")
         self._response = response
+        detail_msg = self.detail or response.text
+        super().__init__(f"Server returned {self.status_code}: {detail_msg}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,46 @@
+"""Tests for src/aiod/calls/utils.py."""
+
+
+import requests
+import responses
+
+from aiod.calls.utils import ServerError
+
+
+@responses.activate
+def test_server_error_json_response():
+    """ServerError correctly parses detail and reference from a JSON response."""
+    responses.post(
+        "http://example.com/test",
+        json={"detail": "Not found", "reference": "abc123"},
+        status=404,
+    )
+    resp = requests.post("http://example.com/test")
+
+    error = ServerError(resp)
+
+    assert error.status_code == 404
+    assert error.detail == "Not found"
+    assert error.reference == "abc123"
+    assert "404" in str(error)
+    assert "Not found" in str(error)
+
+
+@responses.activate
+def test_server_error_non_json_response():
+    """ServerError defaults detail and reference to None for non-JSON responses."""
+    responses.post(
+        "http://example.com/test",
+        body=b"<html>Bad Gateway</html>",
+        status=502,
+        content_type="text/html",
+    )
+    resp = requests.post("http://example.com/test")
+
+    error = ServerError(resp)
+
+    assert error.status_code == 502
+    assert error.detail is None
+    assert error.reference is None
+    assert "502" in str(error)
+    assert isinstance(error, RuntimeError)


### PR DESCRIPTION
Fixes #88

## Problem
`ServerError.__init__()` called `response.json()` unconditionally.
When a reverse proxy (e.g. Nginx) returns an HTML 502 page, this raised
`JSONDecodeError`, masking the original server error.

Additionally, `super().__init__()` was never called, so
`str(ServerError(...))` always returned an empty string.

## Changes
- Wrap `response.json()` in `try/except (ValueError, requests.exceptions.JSONDecodeError)`,
  defaulting to `{}` on failure
- Call `response.json()` only once (stored in a local variable)
- Add `super().__init__()` with message: `"Server returned {code}: {detail}"`
- Fix all pre-existing E501 line-too-long violations in `utils.py` (were blocking CI)
- Add `tests/test_utils.py` with unit tests for JSON and non-JSON responses

## Testing
- `ruff check` passes with zero errors
- 292 tests pass with no regressions
