### PR TITLE
Fix JSONDecodeError when API returns non-JSON error responses

### DIFF
--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -21,6 +21,18 @@ from aiod.calls.urls import (
 from aiod.calls.utils import ServerError, format_response, wrap_calls
 from aiod.configuration import config
 
+def _safe_json(res: requests.Response):
+    """Safely parse JSON response."""
+    if not res.text or not res.text.strip():
+        raise RuntimeError(f"Server error {res.status_code}: empty response")
+
+    try:
+        return res.json()
+    except Exception:
+        raise RuntimeError(
+            f"Invalid JSON response from server (status {res.status_code}): {res.text}"
+        )
+
 
 def get_any_asset(
     identifier: str,
@@ -55,8 +67,8 @@ def get_any_asset(
         raise KeyError(f"Asset with identifier {identifier!r} not found.")
     if res.status_code != HTTPStatus.OK:
         raise ServerError(res)
-    return format_response(res.json(), data_format)
-
+    data = _safe_json(res)
+    return format_response(data, data_format)
 
 def get_list(
     *,
@@ -99,9 +111,13 @@ def get_list(
         url,
         timeout=config.request_timeout_seconds,
     )
-    resources = format_response(res.json(), data_format)
-    return resources
 
+    # check server response
+    if res.status_code != HTTPStatus.OK:
+        raise ServerError(res)
+    data = _safe_json(res)   
+    resources = format_response(data, data_format)
+    return resources
 
 def delete_asset(
     *,
@@ -290,7 +306,7 @@ def counts(*, asset_type: str, version: str | None = None, per_platform: bool = 
     """
     url = url_to_resource_counts(version, per_platform, asset_type)
     res = requests.get(url, timeout=config.request_timeout_seconds)
-    return res.json()
+    return _safe_json(res)
 
 
 def get_asset(
@@ -332,7 +348,8 @@ def get_asset(
     )
     if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail"):
         raise KeyError(f"No {asset_type} with identifier {identifier!r} found.")
-    resources = format_response(res.json(), data_format)
+    data = _safe_json(res)
+    resources = format_response(data, data_format)
     return resources
 
 
@@ -464,7 +481,8 @@ def search(
         url,
         timeout=config.request_timeout_seconds,
     )
-    resources = format_response(res.json()["resources"], data_format)
+    data = _safe_json(res)
+    resources = format_response(data["resources"], data_format)
     return resources
 
 
@@ -550,7 +568,15 @@ async def get_list_async(
 async def _fetch_resources(urls) -> list[dict]:
     async def _fetch_data(session, url) -> dict:
         async with session.get(url, timeout=config.request_timeout_seconds) as response:
-            return await response.json()
+            text = await response.text()
+            if not text.strip():
+                raise RuntimeError(f"Server error {response.status}: empty response")
+            try:
+                return await response.json()
+            except Exception:
+                raise RuntimeError(
+                    f"Invalid JSON response from server (status {response.status}): {text}"
+                )
 
     async with aiohttp.ClientSession() as session:
         tasks = [_fetch_data(session, url) for url in urls]

--- a/src/aiod/calls/utils.py
+++ b/src/aiod/calls/utils.py
@@ -57,6 +57,15 @@ class ServerError(RuntimeError):
 
     def __init__(self, response: requests.Response):
         self.status_code = response.status_code
-        self.detail = response.json().get("detail")
-        self.reference = response.json().get("reference")
         self._response = response
+
+        try:
+            data = response.json()
+            self.detail = data.get("detail")
+            self.reference = data.get("reference")
+        except Exception:
+            # fallback if response is not JSON
+            self.detail = response.text
+            self.reference = None
+
+        super().__init__(f"Server error {self.status_code}: {self.detail}")

--- a/tests/test_invalid_json_response.py
+++ b/tests/test_invalid_json_response.py
@@ -1,0 +1,20 @@
+import requests
+import pytest
+from unittest.mock import patch, Mock
+
+from aiod.calls.calls import get_list
+
+
+@patch("requests.get")
+def test_get_list_invalid_json(mock_get):
+    mock_response = Mock()
+    mock_response.status_code = 502
+    mock_response.text = "Bad Gateway"
+    mock_response.json.side_effect = requests.exceptions.JSONDecodeError(
+        "Expecting value", "", 0
+    )
+
+    mock_get.return_value = mock_response
+
+    with pytest.raises(RuntimeError):
+        get_list(asset_type="datasets")


### PR DESCRIPTION
## Problem
When the API returns a non-JSON error response (e.g. "Bad Gateway"),
ServerError attempts to parse the response using response.json(),
which raises JSONDecodeError.

## Fix
Wrap response.json() in a try/except block and fall back to
response.text when the response is not valid JSON.

## Tests
Added a test to simulate a non-JSON server response to ensure
ServerError handles it gracefully.

All tests pass locally.