### PR TITLE
[ENH]: updated aiod.get() to support dataset loading

### DIFF
--- a/src/aiod/__init__.py
+++ b/src/aiod/__init__.py
@@ -1,10 +1,10 @@
 from aiod import bookmarks, taxonomies
+from aiod._get import get
 from aiod.authentication import create_token, get_current_user, invalidate_token
 
 # from aiod.calls.calls import get_any_asset as get
 from aiod.configuration import config
 from aiod.default.counts import asset_counts as counts
-from aiod.models import get
 from aiod.resources import (
     case_studies,
     computational_assets,

--- a/src/aiod/_get.py
+++ b/src/aiod/_get.py
@@ -1,50 +1,40 @@
 """Global get dispatch utility."""
 
+from aiod.data._openml import _get_openml_dataset
+from aiod.models._registry._craft import craft
+
 __all__ = ["get"]
+
 
 def get(id: str):
     """Retrieve model or dataset by identifier.
 
     For models, pass the class name directly, e.g., "RandomForestClassifier".
 
-    For datasets, use pattern "source:identifier"
-    ex.: "openml:31" loads OpenML dataset with ID 31
+    For datasets, use OpenML URI format:
+    - "openml://31" — OpenML dataset by ID
+    - "openml://credit-g" — OpenML dataset by name
 
     Parameters
     ----------
-    id: 
-        If it contains a ":" it resolves to dataset loader.
-        Otherwise, resolves as a model identifier.
+    id : str
+        Identifier string. Models are class names.
+        OpenML datasets use "openml://<id-or-name>" format.
 
     Returns
     -------
     object
         For models: the model class.
-        For datasets: a dataset loader instance.
+        For OpenML datasets: a native openml.OpenMLDataset instance.
+
+    Examples
+    --------
+    >>> clf = get("RandomForestClassifier")  # doctest: +SKIP
+    >>> ds = get("openml://31")  # doctest: +SKIP
     """
-    if ":" in id:
-        source, identifier = id.split(":", 1)
-        source = source.strip().lower()
-        identifier = identifier.strip()
+    if id.startswith("openml://"):
+        identifier = id.replace("openml://", "", 1)
 
-        if source == "openml":
-            return _get_openml_dataset(identifier)
-        else:
-            raise ValueError(f"Unknown dataset source '{source}'. ")
+        return _get_openml_dataset(identifier)
 
-    from aiod.models._registry._get import get as _model_get
-
-    return _model_get(id)
-
-def _get_openml_dataset(identifier):
-    """Create an OpenMLDataset for the given ID."""
-    from aiod.data import OpenMLDataset
-
-    try:
-        dataset_id = int(identifier)
-    except ValueError:
-        raise ValueError(
-            f"OpenML identifier must be an integer dataset ID, got '{identifier}'."
-        ) from None
-
-    return OpenMLDataset(dataset_id=dataset_id)
+    return craft(id)

--- a/src/aiod/_get.py
+++ b/src/aiod/_get.py
@@ -1,7 +1,6 @@
 """Global get dispatch utility."""
 
 from aiod.data._openml import _get_openml_dataset
-from aiod.models._registry._craft import craft
 
 __all__ = ["get"]
 
@@ -37,4 +36,6 @@ def get(id: str):
 
         return _get_openml_dataset(identifier)
 
-    return craft(id)
+    from aiod.models._registry._get import get as get_model
+
+    return get_model(id)

--- a/src/aiod/_get.py
+++ b/src/aiod/_get.py
@@ -1,9 +1,50 @@
 """Global get dispatch utility."""
 
-# currently just a forward to models
-# to discuss and possibly
-# todo: add global get utility here
-# in general, e.g., datasets will not have same name as models etc
-from aiod.models import get
-
 __all__ = ["get"]
+
+def get(id: str):
+    """Retrieve model or dataset by identifier.
+
+    For models, pass the class name directly, e.g., "RandomForestClassifier".
+
+    For datasets, use pattern "source:identifier"
+    ex.: "openml:31" loads OpenML dataset with ID 31
+
+    Parameters
+    ----------
+    id: 
+        If it contains a ":" it resolves to dataset loader.
+        Otherwise, resolves as a model identifier.
+
+    Returns
+    -------
+    object
+        For models: the model class.
+        For datasets: a dataset loader instance.
+    """
+    if ":" in id:
+        source, identifier = id.split(":", 1)
+        source = source.strip().lower()
+        identifier = identifier.strip()
+
+        if source == "openml":
+            return _get_openml_dataset(identifier)
+        else:
+            raise ValueError(f"Unknown dataset source '{source}'. ")
+
+    from aiod.models._registry._get import get as _model_get
+
+    return _model_get(id)
+
+def _get_openml_dataset(identifier):
+    """Create an OpenMLDataset for the given ID."""
+    from aiod.data import OpenMLDataset
+
+    try:
+        dataset_id = int(identifier)
+    except ValueError:
+        raise ValueError(
+            f"OpenML identifier must be an integer dataset ID, got '{identifier}'."
+        ) from None
+
+    return OpenMLDataset(dataset_id=dataset_id)

--- a/src/aiod/data/__init__.py
+++ b/src/aiod/data/__init__.py
@@ -1,5 +1,1 @@
-"""OpenML dataset loaders."""
-
-from aiod.data._openml import OpenMLDataset
-
-__all__ = ["OpenMLDataset"]
+"""OpenML data loading utilities."""

--- a/src/aiod/data/__init__.py
+++ b/src/aiod/data/__init__.py
@@ -1,0 +1,5 @@
+"""OpenML dataset loaders."""
+
+from aiod.data._openml import OpenMLDataset
+
+__all__ = ["OpenMLDataset"]

--- a/src/aiod/data/_openml.py
+++ b/src/aiod/data/_openml.py
@@ -1,0 +1,71 @@
+"""OpenML dataset loader."""
+
+from skbase.base import BaseObject
+
+
+class OpenMLDataset(BaseObject):
+    """Dataset loader for any OpenML dataset.
+
+    Loads a dataset from openml.org by its integer dataset ID.
+    """
+
+    _tags = {
+        "object_type": "dataset",
+        "python_dependencies": "openml",
+    }
+
+    def __init__(self, dataset_id, target=None):
+        self.dataset_id = dataset_id
+        self.target = target
+        super().__init__()
+
+    def load(self, *args):
+        """Load dataset.
+
+        Parameters
+        ----------
+        *args : str
+            Available keys: "X", "y"
+
+        Returns
+        -------
+        object or tuple
+            Requested dataset components.
+        """
+        if len(args) == 0:
+            args = ("X", "y")
+
+        valid_keys = self.keys()
+        for arg in args:
+            if arg not in valid_keys:
+                raise ValueError(f"Invalid key {arg}. Valid keys: {valid_keys}")
+
+        X, y = self._load_dataset()
+
+        cache = {"X": X, "y": y}
+        res = [cache[key] for key in args]
+
+        if len(res) == 1:
+            return res[0]
+
+        return tuple(res)
+
+    def keys(self):
+        """Return available dataset components."""
+        return ["X", "y"]
+
+    def _load_dataset(self):
+        """Fetch dataset from OpenML and return (X, y)."""
+        import openml
+
+        dataset = openml.datasets.get_dataset(self.dataset_id)
+
+        target = self.target
+        if target is None:
+            target = dataset.default_target_attribute
+
+        X, y, _, _ = dataset.get_data(target=target)
+        return X, y
+
+    def __getitem__(self, key):
+        return self.load(key)

--- a/src/aiod/data/_openml.py
+++ b/src/aiod/data/_openml.py
@@ -8,7 +8,7 @@ def _get_openml_dataset(identifier):
     ----------
     identifier : str or int
         OpenML dataset ID (integer) or name (string).
-        Examples: "31", "credit-g"
+        Examples: 31, "credit-g"
 
     Returns
     -------
@@ -17,21 +17,11 @@ def _get_openml_dataset(identifier):
 
     Raises
     ------
-    ValueError
+    ImportError
+        If openml-python is not installed.
+    Exception
         If the identifier is invalid or dataset not found.
     """
-    try:
-        import openml
-    except ImportError as e:
-        msg = (
-            "openml-python is required to load OpenML datasets. "
-            "Install it with: pip install openml"
-        )
-        raise ImportError(msg) from e
+    import openml
 
-    try:
-        dataset_id = int(identifier)
-        return openml.datasets.get_dataset(dataset_id)
-    except ValueError:
-        # Not an integer, try as a name string
-        return openml.datasets.get_dataset(identifier)
+    return openml.datasets.get_dataset(identifier)

--- a/src/aiod/data/_openml.py
+++ b/src/aiod/data/_openml.py
@@ -1,71 +1,37 @@
-"""OpenML dataset loader."""
-
-from skbase.base import BaseObject
+"""OpenML dataset dispatcher."""
 
 
-class OpenMLDataset(BaseObject):
-    """Dataset loader for any OpenML dataset.
+def _get_openml_dataset(identifier):
+    """Get an OpenML dataset by ID or name.
 
-    Loads a dataset from openml.org by its integer dataset ID.
+    Parameters
+    ----------
+    identifier : str or int
+        OpenML dataset ID (integer) or name (string).
+        Examples: "31", "credit-g"
+
+    Returns
+    -------
+    openml.OpenMLDataset
+        A native OpenML dataset object.
+
+    Raises
+    ------
+    ValueError
+        If the identifier is invalid or dataset not found.
     """
-
-    _tags = {
-        "object_type": "dataset",
-        "python_dependencies": "openml",
-    }
-
-    def __init__(self, dataset_id, target=None):
-        self.dataset_id = dataset_id
-        self.target = target
-        super().__init__()
-
-    def load(self, *args):
-        """Load dataset.
-
-        Parameters
-        ----------
-        *args : str
-            Available keys: "X", "y"
-
-        Returns
-        -------
-        object or tuple
-            Requested dataset components.
-        """
-        if len(args) == 0:
-            args = ("X", "y")
-
-        valid_keys = self.keys()
-        for arg in args:
-            if arg not in valid_keys:
-                raise ValueError(f"Invalid key {arg}. Valid keys: {valid_keys}")
-
-        X, y = self._load_dataset()
-
-        cache = {"X": X, "y": y}
-        res = [cache[key] for key in args]
-
-        if len(res) == 1:
-            return res[0]
-
-        return tuple(res)
-
-    def keys(self):
-        """Return available dataset components."""
-        return ["X", "y"]
-
-    def _load_dataset(self):
-        """Fetch dataset from OpenML and return (X, y)."""
+    try:
         import openml
+    except ImportError as e:
+        msg = (
+            "openml-python is required to load OpenML datasets. "
+            "Install it with: pip install openml"
+        )
+        raise ImportError(msg) from e
 
-        dataset = openml.datasets.get_dataset(self.dataset_id)
-
-        target = self.target
-        if target is None:
-            target = dataset.default_target_attribute
-
-        X, y, _, _ = dataset.get_data(target=target)
-        return X, y
-
-    def __getitem__(self, key):
-        return self.load(key)
+    try:
+        dataset_id = int(identifier)
+        return openml.datasets.get_dataset(dataset_id)
+    except ValueError:
+        # Not an integer, try as a name string
+        return openml.datasets.get_dataset(identifier)

--- a/src/aiod/data/tests/__init__.py
+++ b/src/aiod/data/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Openml Dataset module tests."""

--- a/src/aiod/data/tests/test_openml.py
+++ b/src/aiod/data/tests/test_openml.py
@@ -1,5 +1,5 @@
 # ruff: noqa: N802
-"""Tests for OpenML dataset dispatch via aiod.get()."""
+"""Tests for OpenML dataset loading."""
 
 import pytest
 from skbase.utils.dependencies import _check_soft_dependencies
@@ -10,12 +10,12 @@ from skbase.utils.dependencies import _check_soft_dependencies
     reason="openml-python not installed",
 )
 @pytest.mark.parametrize("identifier", [31, "credit-g"])
-def test_get_openml(identifier):
-    """aiod.get('openml://...') returns a valid OpenMLDataset."""
+def test_get_openml_dataset(identifier):
+    """_get_openml_dataset returns a valid OpenMLDataset."""
     import openml
 
-    from aiod import get
+    from aiod.data._openml import _get_openml_dataset
 
-    ds = get(f"openml://{identifier}")
+    ds = _get_openml_dataset(identifier)
 
     assert isinstance(ds, openml.OpenMLDataset)

--- a/src/aiod/data/tests/test_openml_dataloaders.py
+++ b/src/aiod/data/tests/test_openml_dataloaders.py
@@ -1,101 +1,33 @@
-# ruff: noqa: N802, E402
-"""Tests for OpenML dataset loaders."""
+# ruff: noqa: N802
+"""Tests for OpenML dataset dispatch via aiod.get()."""
 
 import pytest
-
-openml = pytest.importorskip("openml")
-
-from aiod.data import OpenMLDataset
+from skbase.utils.dependencies import _check_soft_dependencies
 
 
-@pytest.fixture
-def dataset():
-    return OpenMLDataset(dataset_id=31)
-
-
-def test_load_returns_X_y(dataset):
-    """load() should return X, y."""
-    X, y = dataset.load()
-
-    assert X is not None
-    assert y is not None
-    assert len(X) == len(y)
-
-
-def test_load_single_key(dataset):
-    """load('X') and load('y') should return individual objects."""
-    X = dataset.load("X")
-    y = dataset.load("y")
-
-    assert X is not None
-    assert y is not None
-    assert len(X) == len(y)
-
-
-def test_load_multiple_args(dataset):
-    """load('X','y') should return tuple in order."""
-    X, y = dataset.load("X", "y")
-
-    assert isinstance((X, y), tuple)
-    assert len(X) == len(y)
-
-
-def test_invalid_key_raises(dataset):
-    """Invalid key should raise ValueError."""
-    with pytest.raises(ValueError):
-        dataset.load("invalid_key")
-
-
-def test_keys_method(dataset):
-    """keys() should list available dataset components."""
-    keys = dataset.keys()
-
-    assert "X" in keys
-    assert "y" in keys
-    assert len(keys) == 2
-
-
-def test_explicit_target():
-    """Explicit target parameter should work."""
-    ds = OpenMLDataset(dataset_id=31, target="class")
-    X, y = ds.load()
-
-    assert X is not None
-    assert y is not None
-    assert len(X) == len(y)
-
-
-def test_data_matches_openml_directly():
-    """Dataset wrapper should match raw openml output."""
-    import openml
-
-    ds = OpenMLDataset(dataset_id=31)
-    X1, y1 = ds.load()
-
-    raw = openml.datasets.get_dataset(31)
-    X2, y2, _, _ = raw.get_data(target=raw.default_target_attribute)
-
-    assert X1.shape == X2.shape
-    assert y1.shape == y2.shape
-
-
-def test_get_openml_instance():
-    """aiod.get('openml:31') should return an OpenMLDataset."""
+@pytest.mark.skipif(
+    not _check_soft_dependencies("openml", severity="none"),
+    reason="openml-python not installed",
+)
+def test_get_openml_by_id():
+    """aiod.get('openml://31') should return an OpenML dataset."""
     from aiod import get
 
-    ds = get("openml:31")
+    ds = get("openml://31")
 
-    assert isinstance(ds, OpenMLDataset)
-    assert ds.dataset_id == 31
-
-    X, y = ds.load()
-    assert X is not None
-    assert y is not None
+    # Check it's a native OpenML dataset
+    assert hasattr(ds, "get_data")
+    assert hasattr(ds, "default_target_attribute")
 
 
-def test_get_openml_invalid_id():
-    """aiod.get('openml:not_a_number') should raise ValueError."""
+@pytest.mark.skipif(
+    not _check_soft_dependencies("openml", severity="none"),
+    reason="openml-python not installed",
+)
+def test_get_openml_by_name():
+    """aiod.get('openml://credit-g') should work with dataset name."""
     from aiod import get
 
-    with pytest.raises(ValueError, match="integer"):
-        get("openml:not_a_number")
+    ds = get("openml://credit-g")
+
+    assert hasattr(ds, "get_data")

--- a/src/aiod/data/tests/test_openml_dataloaders.py
+++ b/src/aiod/data/tests/test_openml_dataloaders.py
@@ -9,25 +9,13 @@ from skbase.utils.dependencies import _check_soft_dependencies
     not _check_soft_dependencies("openml", severity="none"),
     reason="openml-python not installed",
 )
-def test_get_openml_by_id():
-    """aiod.get('openml://31') should return an OpenML dataset."""
+@pytest.mark.parametrize("identifier", [31, "credit-g"])
+def test_get_openml(identifier):
+    """aiod.get('openml://...') returns a valid OpenMLDataset."""
+    import openml
+
     from aiod import get
 
-    ds = get("openml://31")
+    ds = get(f"openml://{identifier}")
 
-    # Check it's a native OpenML dataset
-    assert hasattr(ds, "get_data")
-    assert hasattr(ds, "default_target_attribute")
-
-
-@pytest.mark.skipif(
-    not _check_soft_dependencies("openml", severity="none"),
-    reason="openml-python not installed",
-)
-def test_get_openml_by_name():
-    """aiod.get('openml://credit-g') should work with dataset name."""
-    from aiod import get
-
-    ds = get("openml://credit-g")
-
-    assert hasattr(ds, "get_data")
+    assert isinstance(ds, openml.OpenMLDataset)

--- a/src/aiod/data/tests/test_openml_dataloaders.py
+++ b/src/aiod/data/tests/test_openml_dataloaders.py
@@ -1,0 +1,101 @@
+# ruff: noqa: N802, E402
+"""Tests for OpenML dataset loaders."""
+
+import pytest
+
+openml = pytest.importorskip("openml")
+
+from aiod.data import OpenMLDataset
+
+
+@pytest.fixture
+def dataset():
+    return OpenMLDataset(dataset_id=31)
+
+
+def test_load_returns_X_y(dataset):
+    """load() should return X, y."""
+    X, y = dataset.load()
+
+    assert X is not None
+    assert y is not None
+    assert len(X) == len(y)
+
+
+def test_load_single_key(dataset):
+    """load('X') and load('y') should return individual objects."""
+    X = dataset.load("X")
+    y = dataset.load("y")
+
+    assert X is not None
+    assert y is not None
+    assert len(X) == len(y)
+
+
+def test_load_multiple_args(dataset):
+    """load('X','y') should return tuple in order."""
+    X, y = dataset.load("X", "y")
+
+    assert isinstance((X, y), tuple)
+    assert len(X) == len(y)
+
+
+def test_invalid_key_raises(dataset):
+    """Invalid key should raise ValueError."""
+    with pytest.raises(ValueError):
+        dataset.load("invalid_key")
+
+
+def test_keys_method(dataset):
+    """keys() should list available dataset components."""
+    keys = dataset.keys()
+
+    assert "X" in keys
+    assert "y" in keys
+    assert len(keys) == 2
+
+
+def test_explicit_target():
+    """Explicit target parameter should work."""
+    ds = OpenMLDataset(dataset_id=31, target="class")
+    X, y = ds.load()
+
+    assert X is not None
+    assert y is not None
+    assert len(X) == len(y)
+
+
+def test_data_matches_openml_directly():
+    """Dataset wrapper should match raw openml output."""
+    import openml
+
+    ds = OpenMLDataset(dataset_id=31)
+    X1, y1 = ds.load()
+
+    raw = openml.datasets.get_dataset(31)
+    X2, y2, _, _ = raw.get_data(target=raw.default_target_attribute)
+
+    assert X1.shape == X2.shape
+    assert y1.shape == y2.shape
+
+
+def test_get_openml_instance():
+    """aiod.get('openml:31') should return an OpenMLDataset."""
+    from aiod import get
+
+    ds = get("openml:31")
+
+    assert isinstance(ds, OpenMLDataset)
+    assert ds.dataset_id == 31
+
+    X, y = ds.load()
+    assert X is not None
+    assert y is not None
+
+
+def test_get_openml_invalid_id():
+    """aiod.get('openml:not_a_number') should raise ValueError."""
+    from aiod import get
+
+    with pytest.raises(ValueError, match="integer"):
+        get("openml:not_a_number")


### PR DESCRIPTION
Added dataloader for openml datasets. unlike sklearn dataloader implementation (PR #164) openml has thousands of datasets so a `aiod.get(datasetID)` implementation is done here to load dataset from openml like the following:

```py
import aiod

ds = aiod.get("openml:31")
X, y = ds.load()
print(X,y)
```

Output:
```bash
    checking_status  duration                  credit_history  ... num_dependents  own_telephone foreign_worker
0                <0         6  critical/other existing credit  ...              1            yes            yes
1          0<=X<200        48                   existing paid  ...              1           none            yes
2       no checking        12  critical/other existing credit  ...              2           none            yes
3                <0        42                   existing paid  ...              2           none            yes
4                <0        24              delayed previously  ...              2           none            yes
..              ...       ...                             ...  ...            ...            ...            ...
995     no checking        12                   existing paid  ...              1           none            yes
996              <0        30                   existing paid  ...              1            yes            yes
997     no checking        12                   existing paid  ...              1           none            yes    
998              <0        45                   existing paid  ...              1            yes            yes    
999        0<=X<200        45  critical/other existing credit  ...              1           none            yes    

[1000 rows x 20 columns] 0      good
1       bad
2      good
3      good
4       bad
       ...
995    good
996    good
997    good
998     bad
999    good
Name: class, Length: 1000, dtype: category
Categories (2, object): ['good' < 'bad']
```