### PR TITLE
fix: url_to_get_content skips distribution_idx=0 due to falsy check

### DIFF
--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -58,7 +58,7 @@ def url_to_get_content(
 ) -> str:
     base_url = server_url(version)
     url = f"{base_url}{asset_type}/{identifier}/content"
-    url += f"/{distribution_idx}" if distribution_idx else ""
+    url += f"/{distribution_idx}" if distribution_idx is not None else ""
     return url
 
 


### PR DESCRIPTION
Fixes #169

## What
Changed `if distribution_idx` to `if distribution_idx is not None` 
in `url_to_get_content` (src/aiod/calls/urls.py, line 61).

## Why
`distribution_idx=0` is the default value. Since `0` is falsy in Python,
the old condition silently skipped appending `/0` to the URL, making 
the first distribution unreachable by default.

## Change
- `src/aiod/calls/urls.py` line 61: falsy check → `is not None`