### PR TITLE
fix: url_to_search lowercases user search query due to .lower() on entire query string

### DIFF
--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -33,7 +33,7 @@ def url_to_search(
         for key, value in locals().items()
         if value is not None and value != "" and key not in ["version", "asset_type"]
     }
-    query = urllib.parse.urlencode(query_params, doseq=True).lower()
+    query = urllib.parse.urlencode(query_params, doseq=True)
     base_url = server_url(version)
     url = f"{base_url}search/{asset_type}?{query}"
     return url


### PR DESCRIPTION
Fixes #174

## What
Removed `.lower()` from `url_to_search` in `src/aiod/calls/urls.py`.

## Why
`.lower()` was being called on the entire encoded query string, which 
silently lowercased the user's search input. So `search(query="Robotics")` 
was producing `?search_query=robotics` instead of `?search_query=Robotics`, 
making case-sensitive searches impossible.

## Change
- `src/aiod/calls/urls.py` line 28: removed `.lower()` from urlencode call