### PR TITLE
docs: add comprehensive guides and notebook for using and sharing ML models (resolves #179)

### DIFF
--- a/docs/examples/models.ipynb
+++ b/docs/examples/models.ipynb
@@ -1,0 +1,396 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " This notebook assumes you followed installation instructions in [Getting Started](getting-started.ipynb) or the [home page](../README.md). If you are running this in an online environment such as Colab, install the package first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install aiondemand"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with ML Models on AI-on-Demand\n",
+    "\n",
+    " You can try this notebook interactively on [Google Colab](https://colab.research.google.com/github/aiondemand/aiondemand/blob/develop/docs/examples/models.ipynb) or [Binder](https://mybinder.org/v2/gh/aiondemand/aiondemand/develop?urlpath=%2Fdoc%2Ftree%2Fdocs%2Fexamples%2Fmodels.ipynb).\n",
+    "\n",
+    "This notebook shows you how to:\n",
+    "1. **Browse and search** ML models in the AIoD metadata catalogue\n",
+    "2. **Retrieve metadata** for a specific model\n",
+    "3. **Instantiate indexed models** (scikit-learn, XGBoost, etc.) directly from the SDK\n",
+    "4. **Register your own model** on AIoD so others can find it\n",
+    "\n",
+    "For detailed written guides, see:\n",
+    "- [Using Models from AIoD](../guides/using-models.md)\n",
+    "- [Sharing Models to AIoD](../guides/sharing-models.md)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiod\n",
+    "print(f\"Using aiondemand v{aiod.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Browsing ML Models\n",
+    "\n",
+    "Let's start by seeing what models are available. The `get_list` function returns a pandas DataFrame by default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Grab the first 10 models\n",
+    "models = aiod.ml_models.get_list(limit=10)\n",
+    "models[[\"name\", \"platform\", \"identifier\"]].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also filter by platform. For example, to see only models from Hugging Face:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_models = aiod.ml_models.get_list(platform=\"huggingface\", limit=5)\n",
+    "hf_models[[\"name\", \"platform\", \"identifier\"]].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How Many Models Are There?\n",
+    "\n",
+    "You can get a quick count without fetching all the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total = aiod.ml_models.counts()\n",
+    "print(f\"Total ML models in the catalogue: {total}\")\n",
+    "\n",
+    "# Break it down by platform\n",
+    "per_platform = aiod.ml_models.counts(per_platform=True)\n",
+    "per_platform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Searching for Models\n",
+    "\n",
+    "If you know roughly what you're looking for, `search` is your best friend:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = aiod.ml_models.search(\"image classification\")\n",
+    "results[[\"identifier\", \"name\", \"platform\"]].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also search within a specific field, like the model name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = aiod.ml_models.search(\"bert\", search_field=\"name\")\n",
+    "results[[\"identifier\", \"name\", \"platform\"]].head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Getting Model Details\n",
+    "\n",
+    "Once you've found a model you're interested in, use its identifier to get the full metadata:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's pick the first model from our browse results\n",
+    "first_model = aiod.ml_models.get_list(limit=1, data_format=\"json\")[0]\n",
+    "model_id = first_model[\"identifier\"]\n",
+    "print(f\"Looking up model: {model_id}\")\n",
+    "\n",
+    "# Get the full details\n",
+    "model = aiod.ml_models.get_asset(identifier=model_id, data_format=\"json\")\n",
+    "print(f\"Name:     {model['name']}\")\n",
+    "print(f\"Platform: {model['platform']}\")\n",
+    "print(f\"Keywords: {model.get('keyword', [])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Instantiating Indexed Models\n",
+    "\n",
+    "AIoD indexes models from popular ML libraries like scikit-learn, XGBoost, and mlxtend. You can create instances of these models directly through the SDK — no need to figure out the right import path yourself.\n",
+    "\n",
+    "Let's try it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the RandomForestClassifier class from the AIoD registry\n",
+    "RandomForest = aiod.get(\"RandomForestClassifier\")\n",
+    "print(f\"Got: {RandomForest}\")\n",
+    "\n",
+    "# Create an instance with custom parameters\n",
+    "clf = RandomForest(n_estimators=50, random_state=42)\n",
+    "print(f\"Created: {clf}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's use it on a real dataset — the classic Iris dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "# Load data\n",
+    "X, y = load_iris(return_X_y=True)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)\n",
+    "\n",
+    "# Train and evaluate\n",
+    "clf.fit(X_train, y_train)\n",
+    "accuracy = clf.score(X_test, y_test)\n",
+    "print(f\"Test accuracy: {accuracy:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Building a Pipeline\n",
+    "\n",
+    "You can even compose full pipelines using indexed components:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get pipeline components from the registry\n",
+    "Scaler = aiod.get(\"StandardScaler\")\n",
+    "PCA = aiod.get(\"PCA\")\n",
+    "LogReg = aiod.get(\"LogisticRegression\")\n",
+    "Pipe = aiod.get(\"Pipeline\")\n",
+    "\n",
+    "# Build the pipeline\n",
+    "pipeline = Pipe(steps=[\n",
+    "    (\"scaler\", Scaler()),\n",
+    "    (\"pca\", PCA(n_components=2)),\n",
+    "    (\"classifier\", LogReg(max_iter=200)),\n",
+    "])\n",
+    "\n",
+    "# Train and evaluate\n",
+    "pipeline.fit(X_train, y_train)\n",
+    "print(f\"Pipeline test accuracy: {pipeline.score(X_test, y_test):.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Sharing Your Own Model\n",
+    "\n",
+    "To register a model on AIoD, you first need to authenticate. This requires an AIoD account — go to [aiod.eu](https://aiod.eu) and click **Login** to create one.\n",
+    "\n",
+    "Then authenticate from Python:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment the lines below to authenticate\n",
+    "# aiod.create_token(write_to_file=True)\n",
+    "# aiod.get_current_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Register a Model\n",
+    "\n",
+    "Provide a dictionary of metadata. At minimum, include a `name`, but the more detail you add, the easier it will be for others to find and trust your model.\n",
+    "\n",
+    "⚠️ **Important**: Metadata submitted to the catalogue is publicly visible. Please use real, meaningful data. Test entries will be removed, and repeated offenses may lead to a ban. Use a [local development server](https://github.com/aiondemand/aiod-rest-api) for testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to register (requires authentication)\n",
+    "\n",
+    "# identifier = aiod.ml_models.register(metadata={\n",
+    "#     \"name\": \"My Iris Classifier\",\n",
+    "#     \"description\": {\n",
+    "#         \"plain\": \"A Random Forest classifier trained on the Iris dataset. \"\n",
+    "#                  \"Achieves ~96% test accuracy with 50 trees.\"\n",
+    "#     },\n",
+    "#     \"keyword\": [\"iris\", \"classification\", \"random-forest\", \"scikit-learn\"],\n",
+    "#     \"license\": \"mit\",\n",
+    "# })\n",
+    "# print(f\"Registered! Identifier: {identifier}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Update and Delete\n",
+    "\n",
+    "You can update a specific field without touching the rest:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to update (requires authentication and a registered model)\n",
+    "\n",
+    "# aiod.ml_models.update(\n",
+    "#     identifier=identifier,\n",
+    "#     metadata={\"keyword\": [\"iris\", \"classification\", \"random-forest\", \"scikit-learn\", \"example\"]},\n",
+    "# )\n",
+    "# print(\"Updated keywords!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And if you need to remove a model you registered:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to delete (requires authentication)\n",
+    "# ⚠️ This is permanent — there is no undo!\n",
+    "\n",
+    "# aiod.ml_models.delete(identifier=identifier)\n",
+    "# print(\"Deleted.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## What's Next?\n",
+    "\n",
+    "- 📖 **Detailed guide: Using models** → [Using Models from AIoD](../guides/using-models.md)\n",
+    "- 📖 **Detailed guide: Sharing models** → [Sharing Models to AIoD](../guides/sharing-models.md)\n",
+    "- 📋 **API reference** → [ML Models API](../api/assets/ml_models.md)\n",
+    "- 🔐 **Authentication details** → [Authentication](../api/authentication.md)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 4,
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/guides/sharing-models.md
+++ b/docs/guides/sharing-models.md
@@ -1,0 +1,280 @@
+# Sharing Models to AIoD
+
+So you've trained a model and want to make it discoverable on AI-on-Demand? Great!
+This guide shows you how to register, update, and manage your model metadata on the
+AIoD catalogue step by step.
+
+!!! tip "Before you start"
+
+    Make sure you have the SDK installed:
+
+    ```bash
+    pip install aiondemand
+    ```
+
+    You'll also need an AIoD account — it only takes a minute
+    (see [Step 1](#step-1-create-an-account-and-log-in) below).
+
+---
+
+## Step 1: Create an Account and Log In
+
+Head over to [aiod.eu](https://aiod.eu) and click **Login**. You can sign in with Google,
+your institution, or another supported identity provider — no separate AIoD password needed.
+
+Once you have an account, authenticate from Python:
+
+```python
+import aiod
+
+# This opens a browser-based login flow
+aiod.create_token(write_to_file=True)
+```
+
+The SDK will print a URL and a short code. Open the URL in your browser, enter the code,
+and confirm. That's it — your token is saved to `~/.aiod/token.toml` so you won't need to
+log in again until it expires.
+
+!!! warning "Keep your token safe"
+
+    Never paste your token directly into a script or commit it to version control.
+    The `write_to_file=True` option stores it in a local file outside your project,
+    which is the recommended approach.
+
+You can verify everything works:
+
+```python
+user = aiod.get_current_user()
+print(user)
+# User(name='your-name', roles=('default-roles-aiod', ...))
+```
+
+---
+
+## Step 2: Register a New Model
+
+To share a model, you provide its **metadata** as a Python dictionary. At a minimum, you need
+a `name`, but richer metadata makes your model easier for others to find and use:
+
+```python
+model_metadata = {
+    "name": "My Sentiment Classifier",
+    "description": {
+        "plain": (
+            "A fine-tuned BERT model for binary sentiment classification "
+            "on product reviews. Trained on 50k labelled examples."
+        )
+    },
+    "keyword": ["sentiment-analysis", "bert", "nlp", "text-classification"],
+    "license": "apache-2.0",
+    "alternate_name": ["sentiment-clf-v1"],
+    "relevant_link": [
+        {"name": "GitHub Repository", "url": "https://github.com/you/sentiment-clf"}
+    ],
+}
+
+identifier = aiod.ml_models.register(metadata=model_metadata)
+print(f"Registered! Your model identifier is: {identifier}")
+```
+
+The returned `identifier` is a unique string like `"mlmo_aBcDeFgH..."`. Save it — you'll
+need it to update or delete the entry later.
+
+### Verify It's There
+
+Pull the metadata back from the server to confirm:
+
+```python
+model = aiod.ml_models.get_asset(identifier=identifier, data_format="json")
+print(model["name"])
+# My Sentiment Classifier
+```
+
+---
+
+## Step 3: Update the Metadata
+
+Noticed a typo? Want to add more keywords? Use `update()` to change specific fields
+without touching the rest:
+
+```python
+aiod.ml_models.update(
+    identifier=identifier,
+    metadata={"keyword": ["sentiment-analysis", "bert", "nlp", "reviews", "pytorch"]},
+)
+```
+
+The fields you don't mention stay the same.
+
+### Replace All Metadata
+
+If you want to completely overwrite the metadata (resetting any field you don't include
+back to its default), use `replace()` instead:
+
+```python
+aiod.ml_models.replace(
+    identifier=identifier,
+    metadata={
+        "name": "My Sentiment Classifier v2",
+        "description": {
+            "plain": "Updated v2 model with improved accuracy on product reviews."
+        },
+        "keyword": ["sentiment-analysis", "bert", "nlp", "v2"],
+        "license": "apache-2.0",
+    },
+)
+```
+
+!!! note "`update` vs `replace` — which should I use?"
+
+    - Use **`update()`** when you want to change a few fields and keep everything else.
+    - Use **`replace()`** when you want to start fresh or ensure the metadata is exactly
+      what you specify.
+
+    Under the hood, `update()` fetches the current metadata, merges your changes, and
+    sends the result. If you run into issues with `update()`, try the `replace()` approach
+    shown below in the [manual merge recipe](#recipe-manual-merge-before-replace).
+
+---
+
+## Step 4: Delete a Model
+
+If you registered something by accident, you can remove it:
+
+```python
+aiod.ml_models.delete(identifier=identifier)
+```
+
+!!! danger "Deletion is permanent"
+
+    There is no undo. Once you delete a model entry, it's gone for good.
+
+You can confirm it's been removed:
+
+```python
+try:
+    aiod.ml_models.get_asset(identifier=identifier)
+except KeyError as e:
+    print(e)
+    # "No ml_models with identifier '...' found."
+```
+
+---
+
+## Tips for Good Metadata
+
+Writing good metadata helps others discover and trust your model. Here are a few pointers:
+
+| Field | Why it matters |
+|-------|---------------|
+| `name` | A clear, descriptive name (not "model_v3_final_FINAL") |
+| `description` | What the model does, what data it was trained on, its intended use |
+| `keyword` | Tags that help with search — think about what someone would search for |
+| `license` | Let people know how they can use your model (e.g. `"mit"`, `"apache-2.0"`) |
+| `relevant_link` | Link to a repo, paper, or demo so people can learn more |
+| `alternate_name` | Other names the model might be known by |
+
+!!! tip "Be a good citizen"
+
+    The AIoD catalogue is a shared resource. Please:
+
+    - **Use real data.** Don't upload test entries to the production catalogue. Use a
+      [local server](https://github.com/aiondemand/aiod-rest-api) for experiments.
+    - **Clean up mistakes.** If you accidentally register something, delete it promptly.
+    - **Be descriptive.** The more context you provide, the more useful your contribution is.
+
+---
+
+## Recipes
+
+### Recipe: Manual Merge Before Replace
+
+If `update()` isn't behaving as expected, you can do the merge yourself:
+
+```python
+# 1. Fetch the current metadata
+model = aiod.ml_models.get_asset(identifier=identifier, data_format="json")
+
+# 2. Remove server-managed fields
+del model["aiod_entry"]
+
+# 3. Make your changes
+model["keyword"].append("new-tag")
+model["description"]["plain"] = "Updated description with more details."
+
+# 4. Send it back
+aiod.ml_models.replace(identifier=model["identifier"], metadata=model)
+```
+
+### Recipe: Register and Immediately Verify
+
+A safe pattern for scripts that register models automatically:
+
+```python
+def register_and_verify(metadata):
+    """Register a model and confirm it was saved correctly."""
+    identifier = aiod.ml_models.register(metadata=metadata)
+
+    # Pull it back from the server
+    saved = aiod.ml_models.get_asset(identifier=identifier, data_format="json")
+    assert saved["name"] == metadata["name"], "Name mismatch after registration!"
+
+    print(f"✅ Model '{saved['name']}' registered as {identifier}")
+    return identifier
+```
+
+---
+
+## Advanced Topics
+
+!!! info "This section is optional"
+
+    The content below covers less common scenarios. Skip ahead to
+    [What's Next?](#whats-next) if you don't need these right now.
+
+### Using a Local Test Server
+
+For development and testing, you can run the
+[AIoD REST API](https://github.com/aiondemand/aiod-rest-api) locally and point the
+SDK at it:
+
+```python
+import aiod
+
+aiod.config.api_server = "http://localhost/"
+aiod.config.auth_server = "http://localhost/aiod-auth/"
+
+# You'll need a new token for the local auth server
+aiod.create_token()
+```
+
+This way you can experiment freely without affecting the production catalogue.
+
+### Bulk Registration
+
+If you need to register many models at once, a simple loop works fine:
+
+```python
+models_to_register = [
+    {"name": "Model A", "keyword": ["nlp"], "license": "mit"},
+    {"name": "Model B", "keyword": ["vision"], "license": "apache-2.0"},
+    {"name": "Model C", "keyword": ["tabular"], "license": "bsd-3-clause"},
+]
+
+registered_ids = []
+for metadata in models_to_register:
+    identifier = aiod.ml_models.register(metadata=metadata)
+    registered_ids.append(identifier)
+    print(f"  Registered: {metadata['name']} → {identifier}")
+
+print(f"\nDone! Registered {len(registered_ids)} models.")
+```
+
+---
+
+## What's Next?
+
+- **Discover and use models** → [Using Models from AIoD](using-models.md)
+- **Try it interactively** → [Models Notebook](../examples/models.ipynb)
+- **API reference** → [ML Models API](../api/assets/ml_models.md)
+- **Authentication details** → [Authentication](../api/authentication.md)

--- a/docs/guides/using-models.md
+++ b/docs/guides/using-models.md
@@ -1,0 +1,278 @@
+# Using Models from AIoD
+
+The AI-on-Demand (AIoD) metadata catalogue indexes thousands of ML models from platforms like
+[Hugging Face](https://huggingface.co), [OpenML](https://openml.org), and [Zenodo](https://zenodo.org).
+This guide walks you through finding, exploring, and using those models in your own Python projects.
+
+!!! tip "Before you start"
+
+    Make sure you have the SDK installed:
+
+    ```bash
+    pip install aiondemand
+    ```
+
+    New to the SDK? Check out the [Getting Started](../examples/getting-started.ipynb) example first.
+
+---
+
+## Browse Available Models
+
+The simplest way to see what's available is to grab a list of models:
+
+```python
+import aiod
+
+# Fetch the first 10 models (default)
+models = aiod.ml_models.get_list()
+models.head()
+```
+
+This returns a [pandas](https://pandas.pydata.org/) DataFrame with columns like `name`,
+`platform`, `identifier`, `keyword`, `license`, and more.
+
+### Filter by Platform
+
+If you only care about models from a specific platform, pass the `platform` parameter:
+
+```python
+# Only Hugging Face models
+hf_models = aiod.ml_models.get_list(platform="huggingface", limit=20)
+
+# Only OpenML models
+openml_models = aiod.ml_models.get_list(platform="openml", limit=20)
+```
+
+### Paginate Through Results
+
+By default you get 10 results. Use `offset` and `limit` to page through larger collections:
+
+```python
+# Get models 50–74
+models = aiod.ml_models.get_list(offset=50, limit=25)
+```
+
+### Check How Many Models Exist
+
+Want a quick count instead of the actual data?
+
+```python
+total = aiod.ml_models.counts()
+print(f"There are {total} models in the catalogue!")
+
+# Broken down by platform
+per_platform = aiod.ml_models.counts(per_platform=True)
+print(per_platform)
+# e.g. {'huggingface': 12345, 'openml': 678, ...}
+```
+
+---
+
+## Search for Models
+
+If you know *what* you're looking for, search is faster than browsing:
+
+```python
+# Find models related to "sentiment analysis"
+results = aiod.ml_models.search("sentiment analysis")
+results[["identifier", "name", "platform"]].head()
+```
+
+You can narrow the search to a specific field:
+
+```python
+# Search only in the model name
+results = aiod.ml_models.search("bert", search_field="name")
+```
+
+Or restrict results to certain platforms:
+
+```python
+results = aiod.ml_models.search("image classification", platforms=["huggingface"])
+```
+
+---
+
+## Get Details for a Specific Model
+
+Every asset on AIoD has a unique **identifier** — a short string like `"mlmo_abc123XYZ"`.
+Once you have one, you can pull up the full metadata:
+
+```python
+model = aiod.ml_models.get_asset(identifier="mlmo_abc123XYZ")
+print(model)
+```
+
+The result is a pandas Series (or a Python dict if you prefer):
+
+```python
+# Get raw JSON instead of a pandas Series
+model = aiod.ml_models.get_asset(identifier="mlmo_abc123XYZ", data_format="json")
+print(model["name"])
+print(model["description"])
+print(model["keyword"])
+```
+
+### Look Up by Platform Identifier
+
+If you know the model's ID on its original platform (for example, its Hugging Face repo name),
+you can look it up without knowing the AIoD identifier:
+
+```python
+model = aiod.ml_models.get_asset_from_platform(
+    platform="huggingface",
+    platform_identifier="bert-base-uncased",
+)
+print(model)
+```
+
+---
+
+## Download Model Content
+
+Some models have downloadable files (weights, configs, etc.) registered in their metadata.
+You can fetch them directly:
+
+```python
+raw_bytes = aiod.ml_models.get_content(identifier="mlmo_abc123XYZ")
+
+# Save to disk
+with open("model_file.bin", "wb") as f:
+    f.write(raw_bytes)
+```
+
+If a model has multiple files attached, pick the one you want by its position in the
+distribution list:
+
+```python
+# Download the second file (0-indexed)
+raw_bytes = aiod.ml_models.get_content(
+    identifier="mlmo_abc123XYZ",
+    distribution_idx=1,
+)
+```
+
+---
+
+## Use an Indexed Model Directly
+
+AIoD doesn't just store metadata — it also **indexes** models from popular ML libraries.
+This means you can instantiate well-known estimators straight from the SDK, without writing
+import boilerplate yourself.
+
+Currently indexed libraries include:
+
+| Library | Examples |
+|---------|----------|
+| **scikit-learn** | `RandomForestClassifier`, `LogisticRegression`, `PCA`, `Pipeline`, … |
+| **XGBoost** | `XGBClassifier`, `XGBRegressor` |
+| **mlxtend** | Various classifiers and transformers |
+| **auto-sklearn** | `AutoSklearnClassifier` |
+
+### Quick Example
+
+```python
+import aiod
+
+# Get a scikit-learn RandomForestClassifier class, ready to use
+RandomForest = aiod.get("RandomForestClassifier")
+
+# Instantiate with your own parameters
+clf = RandomForest(n_estimators=100, max_depth=5)
+
+# Use it like you normally would
+from sklearn.datasets import load_iris
+X, y = load_iris(return_X_y=True)
+clf.fit(X, y)
+print(f"Accuracy: {clf.score(X, y):.2%}")
+```
+
+Under the hood, `aiod.get()` looks up the class in the AIoD model registry and returns
+the actual Python class — no manual imports needed. This is especially helpful when you're
+working with model specifications stored as strings (e.g., from experiment logs or pipelines).
+
+### Build a Pipeline
+
+Since `Pipeline` is also indexed, you can compose full workflows:
+
+```python
+Scaler = aiod.get("StandardScaler")
+SVM = aiod.get("SVC")
+Pipe = aiod.get("Pipeline")
+
+pipe = Pipe(steps=[
+    ("scaler", Scaler()),
+    ("classifier", SVM(kernel="rbf")),
+])
+pipe.fit(X, y)
+```
+
+---
+
+## Advanced Topics
+
+!!! info "This section is optional"
+
+    The sections below cover less common scenarios. Feel free to skip them if the basics
+    above are all you need.
+
+### Async Bulk Retrieval
+
+When you need to fetch metadata for many models at once, async calls are significantly faster
+than looping one-by-one:
+
+```python
+import asyncio
+
+identifiers = ["mlmo_abc123", "mlmo_def456", "mlmo_ghi789"]
+
+# Fetch all three in parallel
+models = asyncio.run(
+    aiod.ml_models.get_assets_async(identifiers)
+)
+print(models)
+```
+
+Or grab a large list asynchronously in batches:
+
+```python
+# Fetch 200 models, 25 at a time
+models = asyncio.run(
+    aiod.ml_models.get_list_async(limit=200, batch_size=25)
+)
+```
+
+### Working with JSON Instead of DataFrames
+
+Every function that returns a DataFrame accepts `data_format="json"` to give you
+plain Python dicts/lists instead:
+
+```python
+models_list = aiod.ml_models.get_list(limit=5, data_format="json")
+# This is a list of dicts
+for m in models_list:
+    print(m["name"], "—", m["platform"])
+```
+
+This is handy when you want to post-process the data yourself or feed it into
+a non-pandas workflow.
+
+### Changing the API Server
+
+By default the SDK talks to the production API at `https://api.aiod.eu/`. If you're
+running a local instance for development or testing, you can point the SDK elsewhere:
+
+```python
+import aiod
+
+aiod.config.api_server = "http://localhost/"
+aiod.config.auth_server = "http://localhost/aiod-auth/"
+```
+
+---
+
+## What's Next?
+
+- **Share your own models** → [Sharing Models to AIoD](sharing-models.md)
+- **Try it interactively** → [Models Notebook](../examples/models.ipynb)
+- **API reference** → [ML Models API](../api/assets/ml_models.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,9 +21,13 @@ extra_css:
 nav:
   - Introduction: 'README.md'
   - 'Developer Setup': 'developer_setup.md'
+  - Guides:
+    - 'Using Models': 'guides/using-models.md'
+    - 'Sharing Models': 'guides/sharing-models.md'
   - Examples:
     - 'Getting Started': 'examples/getting-started.ipynb'
     - Sharing: 'examples/sharing.ipynb'
+    - 'Models': 'examples/models.ipynb'
   - API Reference:
       - 'api/configuration.md'
       - 'api/authentication.md'


### PR DESCRIPTION

This PR addresses issue #179 by adding comprehensive documentation for AIoD end-users on how to use and share indexed machine learning models within their workflows. 
## Changes included
- **[docs/guides/using-models.md](cci:7://file:///c:/Users/ADITYA/Downloads/aiondemand/docs/guides/using-models.md:0:0-0:0)**: Guide for discovering models, retrieving configuration/metadata, downloading dists, and instantiating indexed objects like scikit-learn pipelines via `aiod.get()`.
- **[docs/guides/sharing-models.md](cci:7://file:///c:/Users/ADITYA/Downloads/aiondemand/docs/guides/sharing-models.md:0:0-0:0)**: Walkthrough covering authentication, registering metadata with proper schemas, and safely updating/deleting catalog entries.
- **[docs/examples/models.ipynb](cci:7://file:///c:/Users/ADITYA/Downloads/aiondemand/docs/examples/models.ipynb:0:0-0:0)**: Interactive Jupyter Notebook mirroring [getting-started.ipynb](cci:7://file:///c:/Users/ADITYA/Downloads/aiondemand/docs/examples/getting-started.ipynb:0:0-0:0) that provides copy-pasteable blocks for end-to-end model workflows.
- **[mkdocs.yml](cci:7://file:///c:/Users/ADITYA/Downloads/aiondemand/mkdocs.yml:0:0-0:0)**: Added new `Guides` categorization for the markdown and added the new notebook to the Examples section.
Resolves #179.