### PR TITLE
DOC: align contributing.md and developper_setup.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,6 +67,8 @@ Ready to contribute? Here's how to set up `aiondemand` for local development.
 
 ### Setting up the Development Environment 
 
+For a detailed setup guide, please refer to the [Developer Setup Guide](developer_setup.md).
+
 1. Fork the repository from GitHub by clicking the `fork` button on the webpage.
 1. Clone the fork: `git clone https://github.com/USERNAME/aiondemand.git`. Remember to substitute your username.
 1. Install the project locally (after moving to the new directory). 
@@ -98,6 +100,21 @@ and add a reference to the GitHub issue number as a comment. When adding a featu
 Finally, you can open a pull request with the proposed changes. A core contributor will have a look at the changes,
 and possibly request some changes. After all concerns have been addressed, the contributor will merge the change
 and it will be included in the next release.
+
+### Before Submitting a Pull Request
+
+Ensure your changes pass all checks:
+
+**Run tests:**
+```bash
+python -m pytest -v
+```
+**Run linting:**
+```bash
+ruff check .
+ruff check --fix .
+pre-commit run --all-files
+```
 
 ## Pull Request Guidelines
 

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -93,7 +93,7 @@ docker compose up fill-db-with-examples
 ```bash
 py -3.11 -m venv .venv
 .venv\Scripts\activate
-pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
 pytest src/tests
 ```
 Note: currently the tests are expected to fail. update regarding this is currently tracked here: https://github.com/aiondemand/AIOD-rest-api/issues/681


### PR DESCRIPTION


## Change
Aligned CONTRIBUTING.md and developer_setup.md to be consistent with each other.

- Added a reference to developer_setup.md in CONTRIBUTING.md so new 
  contributors can easily find the detailed setup guide
- Added linting and pre-commit steps to CONTRIBUTING.md to match 
  the contributor workflow already documented in developer_setup.md
- Standardized pip install command to `python -m pip install -e ".[dev]"` 
  across both files

## How to Test
Read both docs/CONTRIBUTING.md and docs/developer_setup.md and verify:
- CONTRIBUTING.md now references developer_setup.md
- Both files use the same pip install command
- Linting steps in CONTRIBUTING.md match developer_setup.md

## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [x] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
Closes #98


