### PR TITLE
[BUG] Fix url_to_search casing (#174), distribution_idx=0 (#169), get…

### DIFF
--- a/src/aiod/authentication/authentication.py
+++ b/src/aiod/authentication/authentication.py
@@ -348,6 +348,10 @@ def get_current_user() -> User:
     content = response.json()
     if response.status_code == http.client.UNAUTHORIZED:
         raise NotAuthenticatedError(content)
+    if response.status_code != http.client.OK:
+        raise RuntimeError(
+            f"Unexpected server response {response.status_code}: {content}"
+        )
     return User(
         name=content["name"],
         roles=tuple(content["roles"]),

--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -33,7 +33,7 @@ def url_to_search(
         for key, value in locals().items()
         if value is not None and value != "" and key not in ["version", "asset_type"]
     }
-    query = urllib.parse.urlencode(query_params, doseq=True).lower()
+    query = urllib.parse.urlencode(query_params, doseq=True)
     base_url = server_url(version)
     url = f"{base_url}search/{asset_type}?{query}"
     return url
@@ -58,7 +58,7 @@ def url_to_get_content(
 ) -> str:
     base_url = server_url(version)
     url = f"{base_url}{asset_type}/{identifier}/content"
-    url += f"/{distribution_idx}" if distribution_idx else ""
+    url += f"/{distribution_idx}" if distribution_idx is not None else ""
     return url
 
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -183,3 +183,64 @@ def test_token_to_file_creates_parent_directory(tmp_path):
     # Calling it multiple times should not result in an error,
     # even if the directory or file already exist.
     token.to_file(token_file)
+
+
+# --- Tests for Issue #185: get_current_user() crash on non-200/401 responses ---
+
+
+def test_get_current_user_500_error(mocked_token: Mock):
+    """get_current_user() should raise RuntimeError on 500 Internal Server Error."""
+    keycloak_openid().token = mocked_token
+
+    with responses.RequestsMock() as mocked_requests:
+        mocked_requests.add(
+            responses.GET,
+            f"{config.api_server}authorization_test",
+            json={"error": "Internal Server Error"},
+            status=500,
+        )
+        set_token(
+            Token(refresh_token="fake_refresh", access_token="fake_token", expires_in_seconds=300)
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected server response 500"):
+            aiod.get_current_user()
+
+
+def test_get_current_user_503_error(mocked_token: Mock):
+    """get_current_user() should raise RuntimeError on 503 Service Unavailable."""
+    keycloak_openid().token = mocked_token
+
+    with responses.RequestsMock() as mocked_requests:
+        mocked_requests.add(
+            responses.GET,
+            f"{config.api_server}authorization_test",
+            json={"error": "Service Unavailable"},
+            status=503,
+        )
+        set_token(
+            Token(refresh_token="fake_refresh", access_token="fake_token", expires_in_seconds=300)
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected server response 503"):
+            aiod.get_current_user()
+
+
+def test_get_current_user_404_error(mocked_token: Mock):
+    """get_current_user() should raise RuntimeError on 404 Not Found."""
+    keycloak_openid().token = mocked_token
+
+    with responses.RequestsMock() as mocked_requests:
+        mocked_requests.add(
+            responses.GET,
+            f"{config.api_server}authorization_test",
+            json={"detail": "Not found"},
+            status=404,
+        )
+        set_token(
+            Token(refresh_token="fake_refresh", access_token="fake_token", expires_in_seconds=300)
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected server response 404"):
+            aiod.get_current_user()
+

--- a/tests/test_url_bugs.py
+++ b/tests/test_url_bugs.py
@@ -1,0 +1,83 @@
+"""Tests for bug fixes in src/aiod/calls/urls.py.
+
+Covers:
+  - Issue #174: url_to_search should preserve user query casing
+  - Issue #169: url_to_get_content should handle distribution_idx=0 correctly
+"""
+
+import pytest
+
+from aiod.calls.urls import url_to_get_content, url_to_search
+
+
+class TestUrlToSearchCasing:
+    """Tests for Issue #174 — search queries must preserve original casing."""
+
+    def test_mixed_case_query_preserved(self):
+        """User query 'Robotics' should NOT be lowercased to 'robotics'."""
+        url = url_to_search("datasets", "Robotics")
+        assert "search_query=Robotics" in url
+
+    def test_uppercase_query_preserved(self):
+        """Fully uppercase queries should be preserved."""
+        url = url_to_search("datasets", "NLP")
+        assert "search_query=NLP" in url
+
+    def test_lowercase_query_unchanged(self):
+        """Lowercase queries should remain lowercase (no regression)."""
+        url = url_to_search("datasets", "robotics")
+        assert "search_query=robotics" in url
+
+    def test_camelcase_query_preserved(self):
+        """CamelCase queries should be preserved."""
+        url = url_to_search("models", "TimeSeriesForecasting")
+        assert "search_query=TimeSeriesForecasting" in url
+
+    def test_query_with_spaces_preserved(self):
+        """Queries with spaces should preserve casing (spaces get encoded)."""
+        url = url_to_search("datasets", "Deep Learning")
+        # urllib encodes spaces as + or %20, but casing must be preserved
+        assert "Deep" in url and "Learning" in url
+
+    def test_search_url_structure(self):
+        """Verify the overall URL structure is correct."""
+        url = url_to_search("datasets", "test")
+        assert "search/datasets?" in url
+        assert "search_query=test" in url
+
+    def test_search_with_platform_filter(self):
+        """Platform filters should work alongside casing preservation."""
+        url = url_to_search("datasets", "MyQuery", platforms=["openml"])
+        assert "search_query=MyQuery" in url
+        assert "platforms=openml" in url
+
+    def test_search_with_pagination(self):
+        """Pagination params should be included correctly."""
+        url = url_to_search("datasets", "Test", offset=10, limit=20)
+        assert "search_query=Test" in url
+        assert "offset=10" in url
+        assert "limit=20" in url
+
+
+class TestUrlToGetContentDistributionIdx:
+    """Tests for Issue #169 — distribution_idx=0 must not be skipped."""
+
+    def test_distribution_idx_zero_included(self):
+        """distribution_idx=0 should produce '/content/0' in the URL."""
+        url = url_to_get_content("datasets", "abc123", distribution_idx=0)
+        assert url.endswith("/content/0"), f"Expected URL to end with /content/0, got: {url}"
+
+    def test_distribution_idx_one(self):
+        """distribution_idx=1 should produce '/content/1' (basic sanity check)."""
+        url = url_to_get_content("datasets", "abc123", distribution_idx=1)
+        assert url.endswith("/content/1"), f"Expected URL to end with /content/1, got: {url}"
+
+    def test_distribution_idx_large_number(self):
+        """Large distribution indices should work correctly."""
+        url = url_to_get_content("datasets", "abc123", distribution_idx=99)
+        assert url.endswith("/content/99"), f"Expected URL to end with /content/99, got: {url}"
+
+    def test_content_url_structure(self):
+        """Verify the overall content URL structure is correct."""
+        url = url_to_get_content("datasets", "data_123", distribution_idx=0)
+        assert "datasets/data_123/content/0" in url


### PR DESCRIPTION
## Change

This PR fixes three bugs in the aiondemand SDK:

### 1. Fix url_to_search lowercasing user queries (#174)
Removed `.lower()` from `url_to_search()` in `src/aiod/calls/urls.py` that silently lowercased the entire query string, making case-sensitive searches impossible.

### 2. Fix url_to_get_content skipping distribution_idx=0 (#169)
Changed `if distribution_idx` to `if distribution_idx is not None` in `src/aiod/calls/urls.py`. Since `0` is falsy in Python, the first distribution was unreachable by default.

### 3. Fix get_current_user() crash on non-200/401 responses (#185)
Added explicit status code validation in `src/aiod/authentication/authentication.py`. Previously, server errors (500, 503, 404) caused a confusing `KeyError` on `content["name"]` instead of a meaningful error message. Now raises `RuntimeError` with status code and response body.

## How to Test

pytest tests/test_url_bugs.py -v
pytest tests/test_authentication.py -v

## Checklist
- [x] Tests have been added or updated to reflect the changes.
- [x] A self-review has been conducted.
- [x] All CI checks pass before pinging a reviewer.

## Related Issues

Closes #174
Closes #169
Closes #185
