### PR TITLE
feat: add get_all() convenience method for auto-pagination

### DIFF
--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -102,6 +102,54 @@ def get_list(
     resources = format_response(res.json(), data_format)
     return resources
 
+def get_all(
+    *,
+    asset_type: str,
+    batch_size: int = 100,
+    version: str | None = None,
+    data_format: Literal["pandas", "json"] = "pandas",
+    show_progress: bool = False,
+) -> pd.DataFrame | list[dict]:
+    """Retrieve all assets from the catalogue, auto-paginating through all pages.
+
+    All parameters must be specified by name.
+
+    Parameters
+    ----------
+    asset_type
+        The type of asset to retrieve (e.g. "datasets", "publications").
+    batch_size
+        Number of records to fetch per internal request (default is 100).
+    version
+        The version of the endpoint (default is None).
+    data_format
+        The desired format for the response (default is "pandas").
+        For "json" format, returns a list of dicts.
+    show_progress
+        If True, display a tqdm progress bar (default is False).
+
+    Returns
+    -------
+    :
+        All retrieved metadata in the specified format.
+    """
+    all_results = []
+    offset = 0
+    while True:
+        page = get_list(
+            asset_type=asset_type,
+            offset=offset,
+            limit=batch_size,
+            version=version,
+            data_format="json",
+        )
+        if not page:
+            break
+        all_results.extend(page)
+        offset += batch_size
+    if data_format == "pandas":
+        return pd.DataFrame(all_results)
+    return all_results
 
 def delete_asset(
     *,
@@ -562,6 +610,7 @@ wrap_common_calls = partial(
     wrap_calls,
     calls=[
         get_list,
+        get_all,
         counts,
         get_asset,
         post_asset,

--- a/src/aiod/resources/case_studies.py
+++ b/src/aiod/resources/case_studies.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/computational_assets.py
+++ b/src/aiod/resources/computational_assets.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/contacts.py
+++ b/src/aiod/resources/contacts.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/datasets.py
+++ b/src/aiod/resources/datasets.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/educational_resources.py
+++ b/src/aiod/resources/educational_resources.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/events.py
+++ b/src/aiod/resources/events.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/experiments.py
+++ b/src/aiod/resources/experiments.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/ml_models.py
+++ b/src/aiod/resources/ml_models.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/news.py
+++ b/src/aiod/resources/news.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/organisations.py
+++ b/src/aiod/resources/organisations.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/persons.py
+++ b/src/aiod/resources/persons.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/platforms.py
+++ b/src/aiod/resources/platforms.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/projects.py
+++ b/src/aiod/resources/projects.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/publications.py
+++ b/src/aiod/resources/publications.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/services.py
+++ b/src/aiod/resources/services.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,

--- a/src/aiod/resources/teams.py
+++ b/src/aiod/resources/teams.py
@@ -2,6 +2,7 @@ from aiod.calls import calls
 
 (
     get_list,
+    get_all,
     counts,
     get_asset,
     register,


### PR DESCRIPTION
## Change
Adds `get_all()` convenience method to `calls.py` that auto-paginates 
through all pages of any asset endpoint, returning the complete catalogue 
in a single call.

Previously users had to write their own pagination loop every time they 
needed all records. `get_all()` moves that loop into the SDK and 
propagates to all 16 asset types via `wrap_common_calls`.

## How to Test
```python
import aiod

# Should return all datasets without manual pagination
all_datasets = aiod.datasets.get_all()
print(len(all_datasets))

# JSON format
all_publications = aiod.publications.get_all(
    batch_size=50, 
    data_format="json"
)
```

## Checklist
- [ ] Tests have been added or updated to reflect the changes, or their 
      absence is explicitly explained.
      → Tests for `get_all()` not yet added. Planning to add in follow-up 
        once implementation approach is confirmed by maintainers.
- [ ] Documentation has been added or updated to reflect the changes, or 
      their absence is explicitly explained.
      → Docstring added. Docs page update pending maintainer confirmation.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub 
    comment explaining it.
- [ ] All CI checks pass before pinging a reviewer, or provide an 
      explanation if they do not.
      → Will verify once PR is open.

## Related Issues
Closes #135