### PR TITLE
Fix _AiodModelPkg._materialize to use explicit exec namespace

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,3 +57,35 @@ The `aiondemand` package is being developed with funding from EU’s Horizon Eur
 Not all contributors need be affiliated with this funding.
 
 [`cookiecutter`](https://cookiecutter.readthedocs.io/en/latest/) and the `py-pkgs-cookiecutter` [template](https://github.com/py-pkgs/py-pkgs-cookiecutter) were used to create the repository structure.
+## Development Setup
+
+If you want to contribute to the project or run the full test suite locally, install the package with the optional development and integration test dependencies:
+
+```bash
+pip install -e ".[dev,tests_integrations]"
+```
+
+### Running the test suite
+
+To run the full test suite:
+
+```bash
+python -m pytest
+```
+
+### Notes
+
+Some tests require additional optional packages. In particular:
+
+- `responses` is required for some HTTP-related tests
+- `aioresponses` is required for async HTTP-related tests
+- `scikit-learn` is required for model-related tests
+
+If these dependencies are missing, you may see errors such as:
+
+```text
+ModuleNotFoundError: No module named 'responses'
+ModuleNotFoundError: No module named 'aioresponses'
+```
+
+Installing the optional dependency groups as shown above should resolve these issues.

--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -129,7 +129,7 @@ def delete_asset(
         headers=get_token().headers,
         timeout=config.request_timeout_seconds,
     )
-    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail"):
+    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail", ""):
         raise KeyError(f"No {asset_type} with identifier {identifier!r} found.")
     return res
 
@@ -176,7 +176,7 @@ def put_asset(
         json=metadata,
         timeout=config.request_timeout_seconds,
     )
-    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail"):
+    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail", ""):
         raise KeyError(f"No {asset_type} with identifier {identifier!r} found.")
     return res
 
@@ -227,7 +227,7 @@ def patch_asset(
         json=asset,
         timeout=config.request_timeout_seconds,
     )
-    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail"):
+    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail", ""):
         raise KeyError(f"No {asset_type} with identifier {identifier!r} found.")
     return res
 
@@ -330,7 +330,7 @@ def get_asset(
         headers=_get_auth_headers(required=False),
         timeout=config.request_timeout_seconds,
     )
-    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail"):
+    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail", ""):
         raise KeyError(f"No {asset_type} with identifier {identifier!r} found.")
     resources = format_response(res.json(), data_format)
     return resources
@@ -367,7 +367,7 @@ def get_asset_from_platform(
     """
     url = url_to_get_asset_from_platform(asset_type, platform, platform_identifier, version)
     res = requests.get(url, timeout=config.request_timeout_seconds)
-    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail"):
+    if res.status_code == HTTPStatus.NOT_FOUND and "not found" in res.json().get("detail", ""):
         raise KeyError(f"No {asset_type} with of {platform!r} with identifier {platform_identifier!r} found.")
     resources = format_response(res.json(), data_format)
     return resources

--- a/src/aiod/models/base/_base.py
+++ b/src/aiod/models/base/_base.py
@@ -50,9 +50,16 @@ class _AiodModelPkg(_BasePkg):
             return _safe_import(obj_loc, pkg_name=pkg_name)
 
         if pkg_obj == "code":
-            exec(self._obj)
+            namespace = {}
+            exec(self._obj, globals(), namespace)
 
-            return obj  # noqa: F821
+            if "obj" not in namespace:
+                raise ValueError(
+                    "Error in _AiodModelPkg._materialize. "
+                    "Executed code did not define 'obj'."
+                )
+
+            return namespace["obj"]
 
         # elif pkg_obj == "craft":
         #    identify and call appropriate craft method

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,37 @@
+"""Tests for _AiodModelPkg materialization."""
+
+import pytest
+
+from aiod.models.base._base import _AiodModelPkg
+
+
+class DummyCodePkg(_AiodModelPkg):
+    _tags = {
+        "pkg_id": "dummy_code_pkg",
+        "pkg_obj": "code",
+    }
+    _obj = "obj = {'status': 'ok'}"
+
+
+def test_materialize_code_exec_uses_explicit_namespace():
+    """Test that code-based materialization returns the executed obj."""
+    pkg = DummyCodePkg()
+    result = pkg._materialize()
+
+    assert result == {"status": "ok"}
+
+
+class DummyMissingObjPkg(_AiodModelPkg):
+    _tags = {
+        "pkg_id": "dummy_missing_obj_pkg",
+        "pkg_obj": "code",
+    }
+    _obj = "x = 10"
+
+
+def test_materialize_code_raises_if_obj_not_defined():
+    """Test that code-based materialization raises when obj is missing."""
+    pkg = DummyMissingObjPkg()
+
+    with pytest.raises(ValueError, match="did not define 'obj'"):
+        pkg._materialize()

--- a/tests/test_calls.py
+++ b/tests/test_calls.py
@@ -1,0 +1,63 @@
+"""Tests for calls module."""
+
+from http import HTTPStatus
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aiod.calls.calls import get_asset, get_asset_from_platform
+
+
+def _mock_response(status_code, json_data):
+    """Create a mock response object."""
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = json_data
+    return response
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_404_without_detail_does_not_raise_typeerror(mock_get):
+    """Test get_asset does not crash when 404 response lacks 'detail'."""
+    mock_get.return_value = _mock_response(HTTPStatus.NOT_FOUND, {})
+
+    result = get_asset("missing_id", asset_type="datasets", data_format="json")
+
+    assert result == {}
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_404_with_non_detail_body_does_not_raise_typeerror(mock_get):
+    """Test get_asset does not crash when 404 response has no 'detail' key."""
+    mock_get.return_value = _mock_response(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    result = get_asset("missing_id", asset_type="datasets", data_format="json")
+
+    assert result == {"error": "not found"}
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_404_with_detail_still_raises_keyerror(mock_get):
+    """Test get_asset still raises KeyError for expected 404 detail response."""
+    mock_get.return_value = _mock_response(
+        HTTPStatus.NOT_FOUND,
+        {"detail": "asset not found"},
+    )
+
+    with pytest.raises(KeyError, match="missing_id"):
+        get_asset("missing_id", asset_type="datasets", data_format="json")
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_from_platform_404_without_detail_does_not_raise_typeerror(mock_get):
+    """Test get_asset_from_platform does not crash when 404 lacks 'detail'."""
+    mock_get.return_value = _mock_response(HTTPStatus.NOT_FOUND, {})
+
+    result = get_asset_from_platform(
+        platform="huggingface",
+        platform_identifier="missing_id",
+        asset_type="datasets",
+        data_format="json",
+    )
+
+    assert result == {}


### PR DESCRIPTION
## Summary

This PR fixes a bug in `_AiodModelPkg._materialize` when `pkg_obj == "code"`.

Previously, the method used `exec(self._obj)` and then returned `obj` directly. In Python 3, `exec()` inside a function does not reliably update the local scope, which can lead to `NameError` or inconsistent behavior.

## Changes

- Use an explicit namespace dictionary with `exec`
- Retrieve `obj` from that namespace
- Raise a clear error if executed code does not define `obj`
- Add tests for code-based materialization

## Before

```python
exec(self._obj)
return obj