### PR TITLE
fix: async auth headers and token timedelta truncation

### DIFF
--- a/src/aiod/authentication/authentication.py
+++ b/src/aiod/authentication/authentication.py
@@ -141,7 +141,7 @@ class Token:
                 kwargs.update(
                     {
                         "access_token": str(doc["access_token"]),
-                        "expires_in_seconds": expires_in.seconds,
+                        "expires_in_seconds": int(expires_in.total_seconds()),
                     }
                 )
         return Token(**kwargs)  # type: ignore[arg-type]

--- a/src/aiod/calls/calls.py
+++ b/src/aiod/calls/calls.py
@@ -552,7 +552,8 @@ async def _fetch_resources(urls) -> list[dict]:
         async with session.get(url, timeout=config.request_timeout_seconds) as response:
             return await response.json()
 
-    async with aiohttp.ClientSession() as session:
+    headers = _get_auth_headers(required=False)
+    async with aiohttp.ClientSession(headers=headers) as session:
         tasks = [_fetch_data(session, url) for url in urls]
         response_data = await asyncio.gather(*tasks)
     return response_data


### PR DESCRIPTION
## Change

This PR fixes two bugs:

1. **Async requests missing auth headers** (`src/aiod/calls/calls.py`): The `_fetch_resources` async helper created an `aiohttp.ClientSession` without passing authentication headers, unlike the sync `get_asset` path which passes `_get_auth_headers(required=False)`. This could cause auth-gated assets to return different results depending on whether the sync or async variant was used. Fixed by passing the same optional auth headers to the session.

2. **Token lifetime truncation beyond 24h** (`src/aiod/authentication/authentication.py`): `Token.from_file()` used `timedelta.seconds` to compute the remaining token lifetime, which only returns the seconds component (0–86399) and ignores the `days` portion. A token expiring in 25 hours would incorrectly report ~3600s instead of ~90000s. Fixed by replacing `expires_in.seconds` with `int(expires_in.total_seconds())`.

## How to Test

1. **Bug 1**: Set an API key/token, then call `get_assets_async` or `get_list_async` on a resource that requires authentication. Verify the response matches what `get_asset` (sync) returns for the same resource.
2. **Bug 2**: Save a token with an expiration date >24h in the future to `~/.aiod/token.toml`. Call `Token.from_file()` and verify `expires_in_seconds` reflects the full lifetime (e.g. ~90000s for a 25h token, not ~3600s).


## Checklist
- [x] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
  - No tests added , both are minimal one-line fixes to existing logic.
- [x] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
  - No documentation changes needed for bug fixes.
- [x] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [ ] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.


## Related Issues

Closes #220
Closes #221