### PR TITLE
fix: handle malformed ~/.aiod/token.toml on import

### DIFF
--- a/src/aiod/authentication/authentication.py
+++ b/src/aiod/authentication/authentication.py
@@ -366,5 +366,5 @@ if _user_token_file.exists() and _user_token_file.is_file():
     try:
         _token = Token.from_file(_user_token_file)
     except Exception as e:
-        e.add_note(f"Failed to load credentials from {str(_user_token_file)!r}")
-        raise e
+        logger.warning(f"Failed to load credentials from {str(_user_token_file)!r}: {e}")
+        _token = None

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,12 +1,16 @@
+import logging
+
 import pytest
 import responses
 from responses import matchers
 
-from unittest.mock import Mock
+from pathlib import Path
+from unittest.mock import Mock, patch
 import requests
 
 import aiod
 from aiod.configuration import config
+from aiod.authentication import authentication
 from aiod.authentication.authentication import (
     keycloak_openid,
     AuthenticationError,
@@ -183,3 +187,40 @@ def test_token_to_file_creates_parent_directory(tmp_path):
     # Calling it multiple times should not result in an error,
     # even if the directory or file already exist.
     token.to_file(token_file)
+
+
+def test_malformed_token_file_logs_warning_and_does_not_crash(tmp_path, caplog):
+    """Issue #223: a corrupt token.toml should NOT crash the import.
+
+    The SDK should log a warning and fall back to unauthenticated mode
+    (_token = None) so the user can still use public endpoints.
+    """
+    # Create a token file with invalid TOML content
+    bad_token_file = tmp_path / "token.toml"
+    bad_token_file.write_text("{bad")  # malformed TOML
+
+    # Patch the module-level file path to point at our bad file
+    with patch.object(authentication, "_user_token_file", bad_token_file):
+        # Reset _token so we can observe the module-level loader logic
+        original_token = authentication._token
+        authentication._token = None
+        try:
+            with caplog.at_level(logging.WARNING, logger="aiod.authentication.authentication"):
+                # Run the same loading logic as the module-level block
+                if bad_token_file.exists() and bad_token_file.is_file():
+                    try:
+                        authentication._token = Token.from_file(bad_token_file)
+                    except Exception as e:
+                        import logging as _logging
+                        _logging.getLogger("aiod.authentication.authentication").warning(
+                            f"Failed to load credentials from {str(bad_token_file)!r}: {e}"
+                        )
+                        authentication._token = None
+
+            # _token must be None — not an exception
+            assert authentication._token is None, "_token should be None for a malformed file"
+            # A warning must have been emitted
+            assert any("Failed to load credentials" in r.message for r in caplog.records), \
+                "Expected a warning about failed credential loading"
+        finally:
+            authentication._token = original_token

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -4,7 +4,6 @@ import pytest
 import responses
 from responses import matchers
 
-from pathlib import Path
 from unittest.mock import Mock, patch
 import requests
 
@@ -194,33 +193,28 @@ def test_malformed_token_file_logs_warning_and_does_not_crash(tmp_path, caplog):
 
     The SDK should log a warning and fall back to unauthenticated mode
     (_token = None) so the user can still use public endpoints.
+
+    We use importlib.reload() so the actual module-level loading block in
+    authentication.py is exercised — not a copy of it.
     """
+    import importlib
+
     # Create a token file with invalid TOML content
     bad_token_file = tmp_path / "token.toml"
     bad_token_file.write_text("{bad")  # malformed TOML
 
-    # Patch the module-level file path to point at our bad file
-    with patch.object(authentication, "_user_token_file", bad_token_file):
-        # Reset _token so we can observe the module-level loader logic
-        original_token = authentication._token
-        authentication._token = None
-        try:
+    original_token = authentication._token
+    try:
+        # Patch the module-level path and reload so the real boot-time block runs
+        with patch.object(authentication, "_user_token_file", bad_token_file):
             with caplog.at_level(logging.WARNING, logger="aiod.authentication.authentication"):
-                # Run the same loading logic as the module-level block
-                if bad_token_file.exists() and bad_token_file.is_file():
-                    try:
-                        authentication._token = Token.from_file(bad_token_file)
-                    except Exception as e:
-                        import logging as _logging
-                        _logging.getLogger("aiod.authentication.authentication").warning(
-                            f"Failed to load credentials from {str(bad_token_file)!r}: {e}"
-                        )
-                        authentication._token = None
+                importlib.reload(authentication)
 
             # _token must be None — not an exception
             assert authentication._token is None, "_token should be None for a malformed file"
             # A warning must have been emitted
             assert any("Failed to load credentials" in r.message for r in caplog.records), \
                 "Expected a warning about failed credential loading"
-        finally:
-            authentication._token = original_token
+    finally:
+        # Restore original token so other tests are not affected
+        authentication._token = original_token


### PR DESCRIPTION
Fixes #223

## What does this PR do?
Fixes a bug where a corrupt or malformed `~/.aiod/token.toml` caused
`import aiod` to fail with an unhandled exception, making the entire
SDK unusable.

## Changes
- `authentication.py`: Instead of re-raising the parse exception, the
  loader now logs a `WARNING` and sets `_token = None`, degrading
  gracefully to unauthenticated mode.
- `test_authentication.py`: Added a test to verify that a malformed
  token file logs a warning and does not crash.