### PR TITLE
API endpoint migration - documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,12 +3,12 @@
 
 # Connect to [AI-on-Demand](https://aiod.eu) in Python.
 
-The [AI-on-Demand](https://aiod.eu) (AIOD) platform empowers AI research and innovation for industry and academia. 
+The [AI-on-Demand](https://aiodp.eu) (AIOD) platform empowers AI research and innovation for industry and academia. 
 At its core is the [metadata catalogue](https://api.aiodp.eu) which indexes countless AI resources, such as datasets, papers, and educational material, 
 from many different platforms such as [Zenodo](https://www.zenodo.org), [OpenML](https://www.openml.org), and [AIDA](https://https://www.i-aida.org/ai-educational-resources/).
 
 This package is mainly intended for users that want to programmatically access the platform to, e.g., build a service, fetch resources in their scripts, or write a connector that registers metadata of another platform with AI-on-Demand. 
-A web interface for browsing and registering assets is available on AI-on-Demand, through [MyLibrary](https://mylibrary.aiod.eu) and the Metadata Catalogue Editor services (to be deployed), respectively.
+A web interface for browsing and registering assets is available on AI-on-Demand, through [the AIoD catalogue](https://catalogue.aiodp.eu) and the [Metadata Catalogue Editor](https://editor.aiodp.eu/), respectively.
 
 ## Installation
 The `aiondemand` package is on [PyPI](https://pypi.org/project/aiondemand/):

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,7 +1,7 @@
 # Authentication
 
 To authenticate with AI-on-Demand, you need an account.
-First navigate to [the web portal](https://aiod.eu/) and click `login`, you can choose
+First navigate to [the web portal](https://aiodp.eu/) and click `login`, you can choose
 to use any authentication service and an account will be created automatically.
 
 !!! danger "Never code your keys into a script"
@@ -30,8 +30,8 @@ The above command will output instructions to console on how to obtain a valid t
 ```bash title="Instructions in the Console"
 Please authenticate using one of two methods:
 
-  1. Navigate to https://auth.aiod.eu/aiod-auth/realms/aiod/device?user_code=ACBC-ARFZ
-  2. Navigate to https://auth.aiod.eu/aiod-auth/realms/aiod/device and enter code ACBC-ARFZ
+  1. Navigate to https://auth.aiodp.eu/aiod-auth/realms/aiod/device?user_code=ACBC-ARFZ
+  2. Navigate to https://auth.aiodp.eu/aiod-auth/realms/aiod/device and enter code ACBC-ARFZ
 
 This workflow will automatically abort after 300 seconds.
 ```

--- a/docs/api/bookmarks.md
+++ b/docs/api/bookmarks.md
@@ -1,7 +1,7 @@
 # Bookmarks
 
 Bookmarks are an easy way for a user to save certain 'favorite' assets that they want to reference.
-Bookmarks can also be set from the [`Resources` service](https://mylibrary.aiod.eu/resources) in the web portal.
+Bookmarks can also be set from the [`Resources` service](https://catalogue.aiodp.eu/resources) in the web portal.
 Bookmarks are private to the user, and to use any of the functions in this module [authentication](authentication.md) is required.
 
 

--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -3,9 +3,9 @@
 ### Defaults
 The default configuration is as follows:
 
-- api_server: "https://api.aiod.eu/"
+- api_server: "https://api.aiodp.eu/"
 - version: "v2"
-- auth_server: "https://auth.aiod.eu/aiod-auth/"
+- auth_server: "https://auth.aiodp.eu/aiod-auth/"
 - realm: "aiod"
 - client_id: "aiod-sdk"
 - request_timeout_seconds: 10

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -146,7 +146,7 @@ Go to `http://localhost:9200` and login with:
 ### Using the SDK with a Local Backend
 
 
-By default, the SDK (`aiod`) connects to the remote production backend at `https://api.aiod.eu/`. To use your locally running backend (for development or testing), update the API server URL in your code as follows:
+By default, the SDK (`aiod`) connects to the remote production backend at `https://api.aiodp.eu/`. To use your locally running backend (for development or testing), update the API server URL in your code as follows:
 
 ### 1. Configure SDK to Use Local Backend
 

--- a/docs/examples/sharing.ipynb
+++ b/docs/examples/sharing.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "🧑‍💻 You can try this notebook interactively on [Google Colab](https://colab.research.google.com/github/aiondemand/aiondemand/blob/develop/docs/examples/sharing.ipynb) or [Binder](https://mybinder.org/v2/gh/aiondemand/aiondemand/develop?urlpath=%2Fdoc%2Ftree%2Fdocs%2Fexamples%2Fsharing.ipynb).\n",
     "\n",
-    "To share metadata on AI-on-Demand, you need to have an AI-on-Demand account. To obtain one, head over to [the AI-on-Demand website](https://aiod.eu) and click 'login'. You will be prompted to sign in with an authentication service (e.g., Google or an institutional login), which will initiate the account creation process. You can later use these same credentials to log in to your account - no need for AI-on-Demand specific login credentials! 🎉\n",
+    "To share metadata on AI-on-Demand, you need to have an AI-on-Demand account. To obtain one, head over to [the AI-on-Demand website](https://research.aiodp.eu) and click 'login'. You will be prompted to sign in with an authentication service (e.g., Google or an institutional login), which will initiate the account creation process. You can later use these same credentials to log in to your account - no need for AI-on-Demand specific login credentials! 🎉\n",
     "\n",
     "After creating an account, we can use it to grant us programmatic access from Python.\n",
     "The programmatic access is granted through an 'access token', which you can obtain by running the code below.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ requires = ["hatchling >= 1.26"]
 build-backend = "hatchling.build"
 
 [project.urls]
-Homepage = "https://www.aiod.eu"
+Homepage = "https://research.aiodp.eu"
 Documentation = "https://aiondemand.github.io/aiondemand/"
 Repository = "https://github.com/aiondemand/aiondemand"
 Issues = "https://github.com/aiondemand/aiondemand/issues"


### PR DESCRIPTION
Updates old references and links to aiod.eu to aiodp.eu.
All in readmes and documentation pages.

