### PR TITLE
Add comprehensive unit tests for calls.py

### DIFF
--- a/tests/test_calls.py
+++ b/tests/test_calls.py
@@ -1,0 +1,324 @@
+import pytest
+from unittest.mock import patch, Mock
+from http import HTTPStatus
+
+from aiod.calls.calls import (
+    get_any_asset,
+    get_asset,
+    get_asset_from_platform,
+    get_assets_async,
+    get_content,
+    get_list,
+    counts,
+    delete_asset,
+    get_list_async,
+    patch_asset,
+    post_asset,
+    put_asset,
+    search,
+)
+from aiod.calls.utils import ServerError
+
+class MockResponse:
+    def __init__(self, json_data, status_code=200, content=b""):
+        self._json = json_data
+        self.status_code = status_code
+        self.content = content
+
+    def json(self):
+        return self._json
+    
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_success(mock_get):
+    mock_get.return_value = MockResponse({"name": "test_asset"}, 200)
+
+    result = get_asset("123", asset_type="datasets", data_format="json")
+
+    assert result["name"] == "test_asset"
+
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert "datasets" in args[0]
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_list_pandas(mock_get):
+    mock_get.return_value = MockResponse([{"id": 1}], 200)
+
+    result = get_list(asset_type="datasets", data_format="pandas")
+
+    assert hasattr(result, "shape") 
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_any_asset_success(mock_get):
+    mock_get.return_value = MockResponse({"id": "123"}, 200)
+
+    result = get_any_asset("123", data_format="json")
+
+    assert result["id"] == "123"
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_content(mock_get):
+    mock_get.return_value = MockResponse({}, 200, content=b"filedata")
+
+    result = get_content(identifier="123", asset_type="datasets")
+
+    assert result == b"filedata"
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_any_asset_server_error(mock_get):
+    mock_get.return_value = MockResponse({}, 500)
+
+    with pytest.raises(ServerError):
+        get_any_asset("123")
+
+@patch("aiod.calls.calls._get_auth_headers")
+@patch("aiod.calls.calls.requests.get")
+def test_get_any_asset_headers(mock_get, mock_headers):
+    mock_headers.return_value = {"Authorization": "test"}
+    mock_get.return_value = MockResponse({"id": "123"}, 200)
+
+    get_any_asset("123")
+
+    _, kwargs = mock_get.call_args
+    assert "headers" in kwargs
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_any_asset_not_found(mock_get):
+    mock_get.return_value = MockResponse({}, HTTPStatus.NOT_FOUND)
+
+    with pytest.raises(KeyError):
+        get_any_asset("invalid")
+
+@patch("aiod.calls.calls.requests.post")
+@patch("aiod.calls.calls.get_token")
+def test_post_asset_failure(mock_token, mock_post):
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_post.return_value = MockResponse({}, 400)
+
+    result = post_asset(asset_type="datasets", metadata={"name": "test"})
+
+    assert result.status_code == 400
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_not_found(mock_get):
+    mock_get.return_value = MockResponse(
+        {"detail": "not found"}, HTTPStatus.NOT_FOUND
+    )
+
+    with pytest.raises(KeyError):
+        get_asset("invalid", asset_type="datasets")
+
+
+@patch("aiod.calls.calls.requests.post")
+@patch("aiod.calls.calls.get_token")
+def test_post_asset_success(mock_token, mock_post):
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_post.return_value = MockResponse({"identifier": "abc"}, 200)
+
+    result = post_asset(asset_type="datasets", metadata={"name": "test"})
+
+    assert result == "abc"
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_list_basic(mock_get):
+    mock_get.return_value = MockResponse([{"id": 1}, {"id": 2}], 200)
+
+    result = get_list(asset_type="datasets", data_format="json")
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_list_with_platform(mock_get):
+    mock_get.return_value = MockResponse([{"id": 1}], 200)
+
+    result = get_list(
+        asset_type="datasets",
+        platform="huggingface",
+        data_format="json",
+    )
+
+    assert result[0]["id"] == 1
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_counts_basic(mock_get):
+    mock_get.return_value = MockResponse(10, 200)
+
+    result = counts(asset_type="datasets")
+
+    assert result == 10
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_counts_per_platform(mock_get):
+    mock_get.return_value = MockResponse({"hf": 5, "openml": 3}, 200)
+
+    result = counts(asset_type="datasets", per_platform=True)
+
+    assert isinstance(result, dict)
+    assert result["hf"] == 5
+
+
+@patch("aiod.calls.calls.requests.delete")
+@patch("aiod.calls.calls.get_token")
+def test_delete_asset_success(mock_token, mock_delete):
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_delete.return_value = MockResponse({}, 200)
+
+    result = delete_asset(asset_type="datasets", identifier="123")
+
+    assert result.status_code == 200
+
+
+@patch("aiod.calls.calls.requests.delete")
+@patch("aiod.calls.calls.get_token")
+def test_delete_asset_not_found(mock_token, mock_delete):
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_delete.return_value = MockResponse(
+        {"detail": "not found"}, HTTPStatus.NOT_FOUND
+    )
+
+    with pytest.raises(KeyError):
+        delete_asset(asset_type="datasets", identifier="invalid")
+
+
+@patch("aiod.calls.calls.requests.put")
+@patch("aiod.calls.calls.get_token")
+def test_put_asset_success(mock_token, mock_put):
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_put.return_value = MockResponse({}, 200)
+
+    res = put_asset(asset_type="datasets", identifier="123", metadata={"name": "test"})
+
+    assert res.status_code == 200
+
+
+@patch("aiod.calls.calls.requests.put")
+@patch("aiod.calls.calls.get_token")
+def test_put_asset_not_found(mock_token, mock_put):
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_put.return_value = MockResponse({"detail": "not found"}, HTTPStatus.NOT_FOUND)
+
+    with pytest.raises(KeyError):
+        put_asset(asset_type="datasets", identifier="invalid", metadata={})
+
+
+@patch("aiod.calls.calls.requests.put")
+@patch("aiod.calls.calls.get_token")
+@patch("aiod.calls.calls.get_asset")
+def test_patch_asset_success(mock_get_asset, mock_token, mock_put):
+    mock_get_asset.return_value = {"aiod_entry": "x", "name": "old"}
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_put.return_value = MockResponse({}, 200)
+
+    res = patch_asset(
+        asset_type="datasets",
+        identifier="123",
+        metadata={"name": "new"}
+    )
+
+    assert res.status_code == 200
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_from_platform_success(mock_get):
+    mock_get.return_value = MockResponse({"id": "123"}, 200)
+
+    res = get_asset_from_platform(
+        platform="hf",
+        platform_identifier="abc",
+        asset_type="datasets",
+        data_format="json"
+    )
+
+    assert res["id"] == "123"
+
+
+@patch("aiod.calls.calls.requests.get")
+def test_get_asset_from_platform_not_found(mock_get):
+    mock_get.return_value = MockResponse(
+        {"detail": "not found"}, HTTPStatus.NOT_FOUND
+    )
+
+    with pytest.raises(KeyError):
+        get_asset_from_platform(
+            platform="hf",
+            platform_identifier="bad",
+            asset_type="datasets"
+        )
+
+@patch("aiod.calls.calls.requests.get")
+def test_search_success(mock_get):
+    mock_get.return_value = MockResponse(
+        {"resources": [{"id": 1}]}, 200
+    )
+
+    res = search(
+        "test",
+        asset_type="datasets",
+        data_format="json"
+    )
+
+    assert isinstance(res, list)
+    assert res[0]["id"] == 1
+
+@pytest.mark.asyncio
+@patch("aiod.calls.calls._fetch_resources")
+async def test_get_assets_async(mock_fetch):
+    mock_fetch.return_value = [{"id": 1}, {"id": 2}]
+
+    res = await get_assets_async(
+        identifiers=["1", "2"],
+        asset_type="datasets",
+        data_format="json"
+    )
+
+    assert isinstance(res, list)
+    assert len(res) == 2
+
+@pytest.mark.asyncio
+@patch("aiod.calls.calls._fetch_resources")
+async def test_get_list_async(mock_fetch):
+    mock_fetch.return_value = [[{"id": 1}], [{"id": 2}]]
+
+    res = await get_list_async(
+        asset_type="datasets",
+        limit=2,
+        batch_size=1,
+        data_format="json"
+    )
+
+    assert len(res) == 2
+
+def test_get_list_async_invalid_batch():
+    import asyncio
+
+    async def run():
+        with pytest.raises(ValueError):
+            await get_list_async(
+                asset_type="datasets",
+                batch_size=0
+            )
+
+    asyncio.run(run())
+
+@patch("aiod.calls.calls.requests.put")
+@patch("aiod.calls.calls.get_token")
+@patch("aiod.calls.calls.get_asset")
+def test_patch_asset_missing_aiod_entry(mock_get_asset, mock_token, mock_put):
+    mock_get_asset.return_value = {"name": "old"} 
+    mock_token.return_value.headers = {"Authorization": "Bearer token"}
+    mock_put.return_value = MockResponse({}, 200)
+
+    with pytest.raises(KeyError):
+        patch_asset(
+            asset_type="datasets",
+            identifier="123",
+            metadata={"name": "new"}
+        )


### PR DESCRIPTION
<!-- 
Please carefully follow the instructions of the template, as they allow for more effective reviews with fewer back-and-forth, making a smoother process for everyone.
Prefer small, independent PRs over big monolithic ones when possible.
If you are only looking for feedback, clearly indicate this and open it as a "draft" instead (use the green "v" button next to "create pull request").
-->


## Change
This PR adds a comprehensive test suite for all functions in `calls.py`, covering both synchronous and asynchronous API interactions.

The test suite includes:
- Unit tests for all public functions:
  - `get_any_asset`
  - `get_asset`
  - `get_list`
  - `get_content`
  - `counts`
  - `post_asset`
  - `put_asset`
  - `patch_asset`
  - `delete_asset`
  - `get_asset_from_platform`
  - `search`
  - `get_assets_async`
  - `get_list_async`
- Coverage of:
  - Successful API responses
  - Error handling (`KeyError`, `ServerError`)
  - Edge cases (invalid batch size, missing `aiod_entry`)
  - Async behavior using `pytest-asyncio`
  - Mocking of external API calls (`requests`, `_fetch_resources`)

This improves reliability, prevents regressions and increases overall test coverage.


## How to Test
1. Navigate to the project root.
2. Run:
   ```bash
   pytest tests/test_calls.py -v
   ```
 3. Expected result:
    ```bash
           
      tests/test_calls.py::test_get_asset_success PASSED                                                                             [  3%]
      tests/test_calls.py::test_get_list_pandas PASSED                                                                               [  7%]
      tests/test_calls.py::test_get_any_asset_success PASSED                                                                         [ 11%]
      tests/test_calls.py::test_get_content PASSED                                                                                   [ 15%]
      tests/test_calls.py::test_get_any_asset_server_error PASSED                                                                    [ 19%]
      tests/test_calls.py::test_get_any_asset_headers PASSED                                                                         [ 23%]
      tests/test_calls.py::test_get_any_asset_not_found PASSED                                                                       [ 26%]
      tests/test_calls.py::test_post_asset_failure PASSED                                                                            [ 30%]
      tests/test_calls.py::test_get_asset_not_found PASSED                                                                           [ 34%]
      tests/test_calls.py::test_post_asset_success PASSED                                                                            [ 38%]
      tests/test_calls.py::test_get_list_basic PASSED                                                                                [ 42%]
      tests/test_calls.py::test_get_list_with_platform PASSED                                                                        [ 46%]
      tests/test_calls.py::test_counts_basic PASSED                                                                                  [ 50%]
      tests/test_calls.py::test_counts_per_platform PASSED                                                                           [ 53%]
      tests/test_calls.py::test_delete_asset_success PASSED                                                                          [ 57%]
      tests/test_calls.py::test_delete_asset_not_found PASSED                                                                        [ 61%]
      tests/test_calls.py::test_put_asset_success PASSED                                                                             [ 65%]
      tests/test_calls.py::test_put_asset_not_found PASSED                                                                           [ 69%]
      tests/test_calls.py::test_patch_asset_success PASSED                                                                           [ 73%]
      tests/test_calls.py::test_get_asset_from_platform_success PASSED                                                               [ 76%]
      tests/test_calls.py::test_get_asset_from_platform_not_found PASSED                                                             [ 80%]
      tests/test_calls.py::test_search_success PASSED                                                                                [ 84%]
      tests/test_calls.py::test_get_assets_async PASSED                                                                              [ 88%]
      tests/test_calls.py::test_get_list_async PASSED                                                                                [ 92%]
      tests/test_calls.py::test_get_list_async_invalid_batch PASSED                                                                  [ 96%]
      tests/test_calls.py::test_patch_asset_missing_aiod_entry PASSED                                                                [100%]
      
              ======================================================== 26 passed in 0.26s =========================================================
     ```

## Checklist
- [X] Tests have been added or updated to reflect the changes, or their absence is explicitly explained.
- [ ] Documentation has been added or updated to reflect the changes, or their absence is explicitly explained.
- [X] A self-review has been conducted checking:
  - No unintended changes have been committed.
  - The changes in isolation seem reasonable.
  - Anything that may be odd or unintuitive is provided with a GitHub comment explaining it (but consider if this should not be a code comment or in the documentation instead).
- [X] All CI checks pass before pinging a reviewer, or provide an explanation if they do not.

## Related Issues
Closes #231 


