### PR TITLE
[ENH] skip test and registry modules in estimator lookup

### DIFF
--- a/src/aiod/models/_registry/_cls_lookup.py
+++ b/src/aiod/models/_registry/_cls_lookup.py
@@ -60,5 +60,8 @@ def _all_objects(obj_type=None):
     from aiod.models.apis._sklearn_apis import _ModelPkgSklearnEstimator
 
     return all_objects(
-        object_types=_ModelPkgSklearnEstimator, package_name="aiod", return_names=False
+        object_types=_ModelPkgSklearnEstimator,
+        package_name="aiod",
+        return_names=False,
+        modules_to_ignore=["tests", "utils", "base", "registry"],
     )


### PR DESCRIPTION
Currently, the lookup via `get` (and internally, `_all_objects`) also crawls test modules, and will therefore depend on `pytest` being present - if `pytest` is not installed, the lookup via `get` will fail without clear error message.

This PR excepts test and registry modules from the lookup, removing the dependency on `pytest` and unrelated imports.