### PR TITLE
Release 0.3.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 ## v0.3.0 (2026-05-07)
 
 - updated backend URLs to `aiodp.eu` endpoints
-- AI model construction feature, indexing into python AI libraries
+- AI model construction feature, indexing into Python AI libraries
 
 ## v0.2.5 (2025-11-06)
 - Temporarily removed client-side checks on `update` calls since they weren't comprehensive enough and in some cases prohibited users from doing legitimate update requests.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
 <!--next-version-placeholder-->
+## v0.3.0 (2026-05-07)
+
+- updated backend URLs to `aiodp.eu` endpoints
+- AI model construction feature, indexing into python AI libraries
+
 ## v0.2.5 (2025-11-06)
 - Temporarily removed client-side checks on `update` calls since they weren't comprehensive enough and in some cases prohibited users from doing legitimate update requests.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,15 @@
 name = "aiondemand"
 description = "Python SDK for the AIoD metadata catalogue"
 authors = [
+  { name = "aiod developers", email = "info@gcos.ai" },
   { name = "Jean Matias", email = "smatias.jean@gmail.com" },
   { name = "Pieter Gijsbers", email = "p.gijsbers@tue.nl" },
 ]
+maintainers = [
+  { name = "aiod developers", email = "info@gcos.ai" },
+]
 readme = "docs/README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 license = "MIT"
 dynamic = ["version"]
 

--- a/src/aiod/__init__.py
+++ b/src/aiod/__init__.py
@@ -58,4 +58,4 @@ __all__ = [
 #         return get(name)
 #     return None
 
-__version__ = "0.2.5"
+__version__ = "0.3.0"


### PR DESCRIPTION
Release PR for version 0.3.0

* version number bump
* changelog
* `pyproject.toml` minimal updates to point to GC.OS as maintenance point of contact