### PR TITLE
[MNT] update release workflow to GC.OS standard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
         run: echo "WHEELNAME=$(ls ./wheelhouse/aiondemand-*none-any.whl)" >> $env:GITHUB_ENV
 
       - name: Install wheel and extras
-        run: python3 -m pip install "${{ env.WHEELNAME }}[dev,tests_integrations]"
+        run: python -m pip install "${{ env.WHEELNAME }}[dev,tests_integrations]"
 
       - run: python -m pytest tests
         name: Run local tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,119 +1,123 @@
-# This workflow is based on the workflow by automl/amltk under the BSD-3-Clause license:
-#   Copyright 2023 AutoML-Freiburg-Hannover-Tübingen
-#   https://github.com/automl/amltk/blob/c3eb4ac29c50bdbdf3c1e19a3c99a8a1e0794fba/LICENSE
+name: Build wheels and publish to PyPI
 
-name: release
 on:
-  workflow_dispatch:
-    inputs:
-      increment:
-        description: "Version segment to increment"
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
-        default: patch
-      prerelease:
-        description: "Pre-lease segment to apply, c.f. https://packaging.python.org/en/latest/specifications/version-specifiers/"
-        type: choice
-        options:
-          - ''
-          - alpha
-          - beta
-          - rc
-        default: ''
-
-permissions:
-  contents: write
-jobs:
-  test-code:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-      - run: python -m pip install ".[dev]"
-      - run: python -m pytest tests
-      - run: python -m pytest -m server tests
-  bump:
-    needs: [test-code]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-tags: 1  # Essential to later commitizen
-          fetch-depth: 0  # Recommended by the action
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - run: git tag  # Debug statement
-      - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
-        id: cz
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          debug: true
-          changelog: false
-          increment: ${{ inputs.increment }}
-          prerelease: ${{ inputs.prerelease }}
-
-  build:
-    needs: [bump]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
-          fetch-tags: 1
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-      - run: python -m pip install build
-      - run: python -m build --sdist
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-output
-          path: dist
   release:
-    needs: [build]  # [docs, build]
+    types: [published]
+
+jobs:
+  check_tag:
+    name: Check tag
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
         with:
-          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
-          fetch-tags: 1
-          fetch-depth: 0
-      - name: Download the build artifiact
-        uses: actions/download-artifact@v4
-        with:
-            name: build-output
-            path: dist
-      - run: ls -R dist
-      - name: "Create Github Release"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          python-version: '3.11'
+
+      - shell: bash
         run: |
-          current_version=$(git tag | sort --version-sort | tail -n 1)
-          echo "Release for ${current_version}"
-          gh release create  \
-            --verify-tag \
-            "${current_version}" "dist/aiondemand-${current_version}.tar.gz"
-  publish:
-    needs: [release]
+          TAG="${{ github.event.release.tag_name }}"
+          GH_TAG_NAME="${TAG#v}"
+          PY_VERSION=$(python - <<'PY'
+          import pathlib, tomllib
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(data.get("project").get("version"))
+          PY
+          )
+          if [ "${GH_TAG_NAME}" != "${PY_VERSION}" ]; then
+            echo "::error::Tag (${GH_TAG_NAME}) does not match pyproject.toml version (${PY_VERSION})."
+            exit 2
+          fi
+
+  build_wheels:
+    needs: check_tag
+    name: Build wheels
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Build wheel
+        run: |
+          uv pip install build
+          uv build --wheel --sdist --out-dir wheelhouse
+        env:
+          UV_SYSTEM_PYTHON: 1
+
+      - name: Store wheels
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheels
+          path: wheelhouse/*
+
+  test_wheels:
+    needs: build_wheels
+    name: Test wheels on ${{ matrix.os }} with ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # to not fail all combinations if just one fail
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: wheels
+          path: wheelhouse
+
+      - name: Display downloaded artifacts
+        run: ls -l wheelhouse
+
+      # Set wheel filename differently for Unix vs Windows
+      - name: Get wheel filename (Unix)
+        if: runner.os != 'Windows'
+        run: echo "WHEELNAME=$(ls ./wheelhouse/aiondemand-*none-any.whl)" >> $GITHUB_ENV
+
+      - name: Get wheel filename (Windows)
+        if: runner.os == 'Windows'
+        run: echo "WHEELNAME=$(ls ./wheelhouse/aiondemand-*none-any.whl)" >> $env:GITHUB_ENV
+
+      - name: Install wheel and extras
+        run: python3 -m pip install "${{ env.WHEELNAME }}[dev,tests_integrations]"
+
+      - run: python -m pytest tests
+        name: Run local tests
+      - run: python -m pytest src/aiod
+        name: Run tests in package
+
+  upload_wheels:
+    name: Upload wheels to PyPI
+    runs-on: ubuntu-latest
+    needs: [build_wheels,test_wheels]
+
     permissions:
       id-token: write
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v8
         with:
-          ref: "main"  # Necessary to download the latest of main as this will have been updated on the step before
-      - uses: actions/download-artifact@v4
-        with:
-            name: build-output
-            path: dist
-      - name: Publish distribution 📦 to PyPI
+          name: wheels
+          path: wheelhouse
+
+      - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheelhouse/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "aiondemand"
-description = "Python SDK for the AIoD metadata catalogue"
+version = "0.3.0"
+description = "Obtain and share AI resources with ease"
 authors = [
   { name = "Jean Matias", email = "smatias.jean@gmail.com" },
   { name = "Pieter Gijsbers", email = "p.gijsbers@tue.nl" },
@@ -8,7 +9,6 @@ authors = [
 readme = "docs/README.md"
 requires-python = ">=3.10"
 license = "MIT"
-dynamic = ["version"]
 
 dependencies = [
     "aiohttp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,6 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/aiod"]
 
-[tool.commitizen]
-name = "cz_conventional_commits"
-version = "0.1.6"
-version_files = ["pyproject.toml:version", "src/aiod/__init__.py:__version__"]
-
 [project.entry-points."mkdocs.plugins"]
 asset-type-replacer = "docs.tools.asset_type_replacer:AssetTypeReplacer"
 


### PR DESCRIPTION
This PR updates the release workflow to one of the GC.OS standard workflows for ease of maintenance.

Indirectly also removes commitizen and less common dependencies from the workflow.