### PR TITLE
[ENH] improve `get` object lookup to allow arbitrary names

### DIFF
--- a/src/aiod/models/_registry/_cls_lookup.py
+++ b/src/aiod/models/_registry/_cls_lookup.py
@@ -3,18 +3,18 @@
 from functools import lru_cache
 
 
-def _get_class(id: str):
-    """Retrieve model class with unique identifier.
+def _retrieve(id: str):
+    """Retrieve python object with unique identifier.
 
     Parameter
     ---------
     id : str
-        unique identifier of class to retrieve
+        unique identifier for object to retrieve
 
     Returns
     -------
-    class
-        retrieved class
+    obj : object
+        retrieved object
 
     Raises
     ------

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -38,14 +38,25 @@ def _extract_var_names(spec):
 
     tree = ast.parse(spec, mode="exec")
 
-    names = {
-        node.id
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
-    }
+    known_assigned = set()
+    unknown = set()
 
     excluded = set(keyword.kwlist) | set(dir(builtins))
-    return names - excluded
+
+    for node in tree.body:
+        # collect reads BEFORE updating assigned names
+        for subnode in ast.walk(node):
+            if isinstance(subnode, ast.Name) and isinstance(subnode.ctx, ast.Load):
+                name = subnode.id
+                if name not in known_assigned and name not in excluded:
+                    unknown.add(name)
+
+        # now record assignments from this statement
+        for subnode in ast.walk(node):
+            if isinstance(subnode, ast.Name) and isinstance(subnode.ctx, ast.Store):
+                known_assigned.add(subnode.id)
+
+    return unknown
 
 
 def craft(spec):

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -18,18 +18,36 @@ will have the same effect as new_est = spec.clone()
 
 import re
 
-from aiod.models._registry._cls_lookup import _get_class
+from aiod.models._registry._cls_lookup import _retrieve
 
 
-def _extract_class_names(spec):
-    """Get all maximal alphanumeric substrings that start with a capital."""
-    pattern = r"\b([A-Z][A-Za-z0-9_]*)\b"
-    cls_name_list = re.findall(pattern, spec)
+def _extract_var_names(spec):
+    """Get all unknown variable names in a python expression.
 
-    EXCLUDE_LIST = ["True", "False", "None"]
-    cls_name_list = [x for x in cls_name_list if x not in EXCLUDE_LIST]
+    Parameters
+    ----------
+    spec : str
+        A python expression as a string.
 
-    return cls_name_list
+    Returns
+    -------
+    names : set of str
+        All variable names in the expression that are not keywords or builtins.
+    """
+    import ast
+    import keyword
+    import builtins
+
+    tree = ast.parse(spec, mode='eval')
+
+    names = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name)
+    }
+
+    excluded = set(keyword.kwlist) | set(dir(builtins))
+    return names - excluded
 
 
 def craft(spec):
@@ -45,13 +63,13 @@ def craft(spec):
     -------
     obj : constructed object
     """
-    cls_names = _extract_class_names(spec)
+    cls_names = _extract_var_names(spec)
 
     register = {}
 
     for name in cls_names:
         try:
-            register[name] = _get_class(name)
+            register[name] = _retrieve(name)
         except Exception as e:
             raise RuntimeError(
                 f"class {name} is required to build spec, but get('{name}') failed"
@@ -94,12 +112,12 @@ def deps(spec, include_test_deps=False):
     """
     dep_strs = []
 
-    for x in _extract_class_names(spec):
+    for x in _extract_var_names(spec):
         try:
-            cls = _get_class(x)
+            cls = _retrieve(x)
         except Exception as e:
             raise RuntimeError(
-                f"class {x} is required to build spec, but get('{x}') failed"
+                f"object {x} is required to build spec, but get('{x}') failed"
             ) from e
 
         def _resolve_disjunctions(dep):
@@ -141,9 +159,9 @@ def imports(spec):
     """
     import_strs = []
 
-    for x in _extract_class_names(spec):
+    for x in _extract_var_names(spec):
         try:
-            cls = _get_class(x)
+            cls = _retrieve(x)
         except Exception as e:
             raise RuntimeError(
                 f"class {x} is required to build spec, but get('{x}') failed"

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -38,23 +38,36 @@ def _extract_var_names(spec):
 
     tree = ast.parse(spec, mode="exec")
 
-    known_assigned = set()
-    unknown = set()
+    assigned = set()
+    used = []
+
+    # First pass: collect in order
+    for node in tree.body:
+        stmt_used = set()
+        stmt_assigned = set()
+
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name):
+                if isinstance(sub.ctx, ast.Load):
+                    stmt_used.add(sub.id)
+                elif isinstance(sub.ctx, ast.Store):
+                    stmt_assigned.add(sub.id)
+
+        used.append((stmt_used, stmt_assigned))
+        assigned |= stmt_assigned
 
     excluded = set(keyword.kwlist) | set(dir(builtins))
 
-    for node in tree.body:
-        # collect reads BEFORE updating assigned names
-        for subnode in ast.walk(node):
-            if isinstance(subnode, ast.Name) and isinstance(subnode.ctx, ast.Load):
-                name = subnode.id
-                if name not in known_assigned and name not in excluded:
-                    unknown.add(name)
+    # Second pass: detect "used before defined"
+    known = set()
+    unknown = set()
 
-        # now record assignments from this statement
-        for subnode in ast.walk(node):
-            if isinstance(subnode, ast.Name) and isinstance(subnode.ctx, ast.Store):
-                known_assigned.add(subnode.id)
+    for stmt_used, stmt_assigned in used:
+        for name in stmt_used:
+            if name not in known and name not in excluded:
+                unknown.add(name)
+
+        known |= stmt_assigned
 
     return unknown
 

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -38,12 +38,12 @@ def _extract_var_names(spec):
     import keyword
     import builtins
 
-    tree = ast.parse(spec, mode='exec')
+    tree = ast.parse(spec, mode="exec")
 
     names = {
         node.id
         for node in ast.walk(tree)
-        if isinstance(node, ast.Name)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
     }
 
     excluded = set(keyword.kwlist) | set(dir(builtins))

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -33,8 +33,8 @@ def _extract_var_names(spec):
         All variable names in the expression that are not keywords or builtins.
     """
     import ast
-    import keyword
     import builtins
+    import keyword
 
     tree = ast.parse(spec, mode="exec")
 

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -63,11 +63,11 @@ def craft(spec):
     -------
     obj : constructed object
     """
-    cls_names = _extract_var_names(spec)
+    var_names = _extract_var_names(spec)
 
     register = {}
 
-    for name in cls_names:
+    for name in var_names:
         try:
             register[name] = _retrieve(name)
         except Exception as e:

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -38,7 +38,7 @@ def _extract_var_names(spec):
     import keyword
     import builtins
 
-    tree = ast.parse(spec, mode='eval')
+    tree = ast.parse(spec, mode='exec')
 
     names = {
         node.id

--- a/src/aiod/models/_registry/_craft.py
+++ b/src/aiod/models/_registry/_craft.py
@@ -16,8 +16,6 @@ new_est = craft(spec)
 will have the same effect as new_est = spec.clone()
 """
 
-import re
-
 from aiod.models._registry._cls_lookup import _retrieve
 
 


### PR DESCRIPTION
This PR improves the `get` object lookup mechanisms to allow arbitrary names, in particular, lower-case starting variable names.

Previously, a regex was used to extract names that look like UpperCamelCase class names.

This PR replaces the heuristic with python native parsing, obtaining the list of unknown objects programmatically.