### PR TITLE
Fix api_server URL normalization

### DIFF
--- a/src/aiod/calls/urls.py
+++ b/src/aiod/calls/urls.py
@@ -89,5 +89,6 @@ def url_to_get_asset_from_platform(
 def server_url(version: str | None = None) -> str:
     version_str = version if version is not None else config.version
     if version_str:
-        return f"{config.api_server}{version_str}/"
+        base = config.api_server.rstrip("/")
+        return f"{base}/{version_str}/"
     return config.api_server

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,25 +1,21 @@
+import pytest
+
 from aiod.calls.urls import url_to_get_list
 from aiod.configuration import config
 
 
-def test_server_without_trailing_slash() -> None:
+@pytest.mark.parametrize(
+    "api_server",
+    [
+        "http://localhost:8000",
+        "http://localhost:8000/",
+    ],
+)
+def test_server_url_normalization(api_server: str) -> None:
     old_api_server = config.api_server
     old_version = config.version
     try:
-        config.api_server = "http://localhost:8000"
-        config.version = "v2"
-        url = url_to_get_list("datasets")
-        assert url == "http://localhost:8000/v2/datasets?offset=0&limit=10"
-    finally:
-        config.api_server = old_api_server
-        config.version = old_version
-
-
-def test_server_with_trailing_slash() -> None:
-    old_api_server = config.api_server
-    old_version = config.version
-    try:
-        config.api_server = "http://localhost:8000/"
+        config.api_server = api_server
         config.version = "v2"
         url = url_to_get_list("datasets")
         assert url == "http://localhost:8000/v2/datasets?offset=0&limit=10"

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,28 @@
+from aiod.calls.urls import url_to_get_list
+from aiod.configuration import config
+
+
+def test_server_without_trailing_slash() -> None:
+    old_api_server = config.api_server
+    old_version = config.version
+    try:
+        config.api_server = "http://localhost:8000"
+        config.version = "v2"
+        url = url_to_get_list("datasets")
+        assert url == "http://localhost:8000/v2/datasets?offset=0&limit=10"
+    finally:
+        config.api_server = old_api_server
+        config.version = old_version
+
+
+def test_server_with_trailing_slash() -> None:
+    old_api_server = config.api_server
+    old_version = config.version
+    try:
+        config.api_server = "http://localhost:8000/"
+        config.version = "v2"
+        url = url_to_get_list("datasets")
+        assert url == "http://localhost:8000/v2/datasets?offset=0&limit=10"
+    finally:
+        config.api_server = old_api_server
+        config.version = old_version


### PR DESCRIPTION
## Summary

Fixed URL construction to correctly handle `config.api_server` with or without a trailing slash.

The base server URL is now normalized before building endpoint paths by removing any trailing `/` and appending the API version using a single separator. This prevents malformed URLs such as:

* `http://localhost:8000v2/`
* `http://localhost:8000//v2/`

and ensures consistent URL generation:

* `http://localhost:8000/v2/...`

## Changes Made

* Normalized `config.api_server` before URL construction
* Ensured API version paths are appended with exactly one `/`
* Added tests covering both:

  * `http://localhost:8000`
  * `http://localhost:8000/`

## Testing

Added test coverage to verify both server URL formats generate identical and valid endpoint URLs.

Closes #241
