### PR TITLE
[MNT] add `pyproject.toml` classifiers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ A web interface for assets is available through [the AIoD catalogue](https://cat
 |---|---|
 | **Open Source** |  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/aiondemand/aiondemand/blob/main/LICENSE) |
 | **Community** | [![!discord](https://img.shields.io/static/v1?logo=discord&label=discord&message=chat&color=lightgreen)](https://discord.gg/A7YDRyvqYE) |
-| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/aiondemand/aiondemand/release.yml?logo=github)](https://github.com/aiondemand/aiondemand/actions/workflows/release.yml) |
+| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/aiondemand/aiondemand/release.yml?logo=github)](https://github.com/aiondemand/aiondemand/actions/workflows/release.yaml) |
 | **Code** |  [![!pypi](https://img.shields.io/pypi/v/aiondemand?color=orange)](https://pypi.org/project/aiondemand/) [![!python-versions](https://img.shields.io/pypi/pyversions/aiondemand)](https://www.python.org/) |
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,34 @@ maintainers = [
   { name = "aiod developers", email = "info@gcos.ai" },
 ]
 readme = "docs/README.md"
-requires-python = ">=3.10,<3.15"
 license = "MIT"
 
+keywords = [
+    "artificial-intelligence",
+    "data-science",
+    "machine-learning",
+    "ai-on-demand",
+]
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "aiohttp",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ maintainers = [
   { name = "aiod developers", email = "info@gcos.ai" },
 ]
 readme = "docs/README.md"
-license = "MIT"
 
 keywords = [
     "artificial-intelligence",
@@ -76,6 +75,9 @@ Documentation = "https://aiondemand.github.io/aiondemand/"
 Repository = "https://github.com/aiondemand/aiondemand"
 Issues = "https://github.com/aiondemand/aiondemand/issues"
 Changelog = "https://aiondemand.github.io/aiondemand/changelog/"
+
+[project.license]
+file = "LICENSE"
 
 [tool.hatch.version]
 path = "src/aiod/__init__.py"


### PR DESCRIPTION
Adds missing `pyproject.toml` classifiers.

The `pyproject.toml` did not have tags or classifiers - this PR adds them.

Also makes minimal fixes to the `pyproject.toml` and README:
* license file reference
* typo in release workflow reference