### PR TITLE
[MNT] fix typo in `README.md` CI badge

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ A web interface for assets is available through [the AIoD catalogue](https://cat
 |---|---|
 | **Open Source** |  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/aiondemand/aiondemand/blob/main/LICENSE) |
 | **Community** | [![!discord](https://img.shields.io/static/v1?logo=discord&label=discord&message=chat&color=lightgreen)](https://discord.gg/A7YDRyvqYE) |
-| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/aiondemand/aiondemand/release.yml?logo=github)](https://github.com/aiondemand/aiondemand/actions/workflows/release.yaml) |
+| **CI/CD** | [![github-actions](https://img.shields.io/github/actions/workflow/status/aiondemand/aiondemand/release.yaml?logo=github)](https://github.com/aiondemand/aiondemand/actions/workflows/release.yaml) |
 | **Code** |  [![!pypi](https://img.shields.io/pypi/v/aiondemand?color=orange)](https://pypi.org/project/aiondemand/) [![!python-versions](https://img.shields.io/pypi/pyversions/aiondemand)](https://www.python.org/) |
 
 ## Installation


### PR DESCRIPTION
fixes a typo in the `README.md` CI badge